### PR TITLE
add transformers to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,6 +7,7 @@ dependencies:
   - pip:
     - aiohttp==3.13.1
     - datasets==4.3.0
+    - dotenv==0.9.9
     - jaxtyping==0.3.3
     - jsonargparse==4.42.0
     - --extra-index-url https://download.pytorch.org/whl/cu126


### PR DESCRIPTION
Closes: #110 

What I did to test: ran the reinstall command, then
- restarted the language server and observed that imports no longer show errors
- ran the pipeline with Wikitext (head=10) and the placeholder model and observed it no longer produces import errors