### PR TITLE
Add qos slurm flag

### DIFF
--- a/src/mirror/slurm_util.py
+++ b/src/mirror/slurm_util.py
@@ -27,3 +27,4 @@ class SlurmConfig:
     open_mode: str = "append"
     signal: str = "SIGHUP@90"
     requeue: bool = True
+    qos: Optional[str] = None

--- a/src/mirror/templates/slurm.jinja
+++ b/src/mirror/templates/slurm.jinja
@@ -8,6 +8,7 @@
 #SBATCH --open-mode=append
 #SBATCH --signal={{ signal }}
 {% if requeue %}#SBATCH --requeue{% endif %}
+{% if qos %}#SBATCH --qos={{ qos }}{% endif %}
 #SBATCH --chdir={{ chdir }}
 
 {{ activate_cmd }}


### PR DESCRIPTION
Tested using standard Wikitext/Llama training runs, with and without `qos` slurm parameter.
Closes #151 

