### PR TITLE
Fix _eval_loop handling of loss

### DIFF
--- a/src/mirror/trainer.py
+++ b/src/mirror/trainer.py
@@ -155,8 +155,8 @@ class Trainer[RawT, ProcessedT, BatchT, ModelOutputT]:
         n_batches = 0
         with torch.no_grad():
             for batch in dataloader:
-                loss = model.training_step(batch)
-                total_loss += loss.item()
+                output = model.training_step(batch)
+                total_loss += output.loss.item()
                 n_batches += 1
         model.train()
         if n_batches == 0:


### PR DESCRIPTION
Tested using Wikitext Llama training runs with `val_data...` and `test_data.init_args.head = 5`, `val_check_interval = 1`
Closes #212 