### PR TITLE
175 adjustments to make the pipeline work with multiple nodes

### DIFF
--- a/src/mirror/callbacks/wandb_callback.py
+++ b/src/mirror/callbacks/wandb_callback.py
@@ -69,8 +69,8 @@ class WandbCallback[RawT, ProcessedT, BatchT, ModelOutputT](
         val_loss: float,
         **kwargs,
     ):
-        assert self.run is not None
-        self.run.log({"val/loss": val_loss}, step=self.step)
+        if self.run:
+            self.run.log({"val/loss": val_loss}, step=self.step)
 
     def on_test_epoch_end(
         self,
@@ -78,8 +78,8 @@ class WandbCallback[RawT, ProcessedT, BatchT, ModelOutputT](
         test_loss: float,
         **kwargs,
     ):
-        assert self.run is not None
-        self.run.log({"test/loss": test_loss}, step=self.step)
+        if self.run:
+            self.run.log({"test/loss": test_loss}, step=self.step)
 
     def on_fit_end(
         self,


### PR DESCRIPTION
Tested with this:
```data:
  class_path: WikitextDataset
  init_args:
    head: 213
do_preprocess: True

trainer:
  callbacks:
    - class_path: CheckpointCallback
      init_args:
        every_n_training_steps: 2
  num_nodes: 4


model: # PlaceholderModel
  class_path: MirrorLlamaModel
  init_args:
    initialization:
      # 3.2-1B

      # 3.2-1B-Instruct

      vocab_size: 128256 # Default: 128256
      hidden_size: 256 # Default: 4096
      intermediate_size: 256 # Default: 11008
      num_hidden_layers: 8 # Default: 32
      num_attention_heads: 8 # Default: 32
      num_key_value_heads: null # Default: None

slurm:
  job_type: compute
  time: "01:00:00"
  # nodes: 2
  gpus_per_node: "1"
  mem_per_cpu: "128G"
  output: "slurm_logs/%j.out"
  open_mode: "append"
  signal: "SIGHUP@90"
  requeue: true

epochs: 2

```
Closes #175 