### PR TITLE
Implement MixedDataset for combining multiple datasets with configura…

### DIFF
--- a/src/mirror/datasets/__init__.py
+++ b/src/mirror/datasets/__init__.py
@@ -1,3 +1,4 @@
 from mirror.datasets.imdb_dataset import ImdbDataset
+from mirror.datasets.mixed_dataset import MixedDataset
 from mirror.datasets.txt_dataset import TxtDataset
 from mirror.datasets.wikitext_dataset import WikitextDataset

--- a/src/mirror/datasets/mixed_dataset.py
+++ b/src/mirror/datasets/mixed_dataset.py
@@ -10,44 +10,21 @@ from mirror.datasets.mirror_dataset import MirrorDataset
 
 
 class MixedDataset[RawT](MirrorDataset[RawT]):
-    """Combines multiple MirrorDataset sub-datasets with configurable sampling weights.
-
-    Uses upsampling: every item from each sub-dataset appears at least once, with items
-    repeated to achieve the specified sampling proportions.
-    """
-
     def __init__(
         self,
         weighted_datasets: Sequence[tuple[MirrorDataset[RawT], float]],
     ) -> None:
-        """Initialize a mixed dataset from weighted sub-datasets.
-
-        Args:
-            weighted_datasets: Sequence of (dataset, weight) tuples. Weights are
-                normalized internally and may be any positive values.
-
-        Raises:
-            ValueError: If weighted_datasets is empty or weights are invalid.
-        """
         super().__init__()
 
-        if not weighted_datasets:
-            raise ValueError("weighted_datasets must not be empty")
-
+        # upscales such that each element from each subdataset is seen at least once
         total_weight = sum(w for _, w in weighted_datasets)
-        if total_weight <= 0:
-            raise ValueError("weights must sum to a positive value")
-
-        norm_weights = [w / total_weight for _, w in weighted_datasets]
-
-        # Compute scale: max dataset size relative to its normalized weight.
-        # scale * norm_weight[i] >= len(dataset[i]) for all i, ensuring full coverage.
-        scale = max(len(ds) / w for (ds, _), w in zip(weighted_datasets, norm_weights))
+        normalized_weights = [w / total_weight for _, w in weighted_datasets]
+        scale = max(len(ds) / w for (ds, _), w in zip(weighted_datasets, normalized_weights))
 
         selected: list[HFDataset] = []
         indices: list[tuple[int, int]] = []
 
-        for ds_idx, ((ds, _), w) in enumerate(zip(weighted_datasets, norm_weights)):
+        for ds_idx, ((ds, _), w) in enumerate(zip(weighted_datasets, normalized_weights)):
             target_count = math.ceil(scale * w)
             ds_len = len(ds)
             upsampled = [i % ds_len for i in range(target_count)]

--- a/src/mirror/datasets/mixed_dataset.py
+++ b/src/mirror/datasets/mixed_dataset.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import math
+from typing import Sequence
+
+from datasets import Dataset as HFDataset
+from datasets import concatenate_datasets
+
+from mirror.datasets.mirror_dataset import MirrorDataset
+
+
+class MixedDataset[RawT](MirrorDataset[RawT]):
+    """Combines multiple MirrorDataset sub-datasets with configurable sampling weights.
+
+    Uses upsampling: every item from each sub-dataset appears at least once, with items
+    repeated to achieve the specified sampling proportions.
+    """
+
+    def __init__(
+        self,
+        weighted_datasets: Sequence[tuple[MirrorDataset[RawT], float]],
+    ) -> None:
+        """Initialize a mixed dataset from weighted sub-datasets.
+
+        Args:
+            weighted_datasets: Sequence of (dataset, weight) tuples. Weights are
+                normalized internally and may be any positive values.
+
+        Raises:
+            ValueError: If weighted_datasets is empty or weights are invalid.
+        """
+        super().__init__()
+
+        if not weighted_datasets:
+            raise ValueError("weighted_datasets must not be empty")
+
+        total_weight = sum(w for _, w in weighted_datasets)
+        if total_weight <= 0:
+            raise ValueError("weights must sum to a positive value")
+
+        norm_weights = [w / total_weight for _, w in weighted_datasets]
+
+        # Compute scale: max dataset size relative to its normalized weight.
+        # scale * norm_weight[i] >= len(dataset[i]) for all i, ensuring full coverage.
+        scale = max(len(ds) / w for (ds, _), w in zip(weighted_datasets, norm_weights))
+
+        selected: list[HFDataset] = []
+        indices: list[tuple[int, int]] = []
+
+        for ds_idx, ((ds, _), w) in enumerate(zip(weighted_datasets, norm_weights)):
+            target_count = math.ceil(scale * w)
+            ds_len = len(ds)
+            upsampled = [i % ds_len for i in range(target_count)]
+
+            selected.append(ds.ds.select(upsampled))
+
+            for i in range(target_count):
+                indices.append((ds_idx, i % ds_len))
+
+        self._ds = concatenate_datasets(selected)
+        self._datasets = [ds for ds, _ in weighted_datasets]
+        self._indices = indices
+
+    @property
+    def ds(self) -> HFDataset:
+        return self._ds
+
+    def __getitem__(self, index: int) -> RawT:
+        ds_idx, item_idx = self._indices[index]
+        return self._datasets[ds_idx][item_idx]
+
+    def __len__(self) -> int:
+        return len(self._indices)

--- a/src/mirror/datasets/mixed_dataset.py
+++ b/src/mirror/datasets/mixed_dataset.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from typing import Sequence
+from typing import Sequence, cast
 
 from datasets import Dataset as HFDataset
 from datasets import concatenate_datasets
@@ -16,35 +16,26 @@ class MixedDataset[RawT](MirrorDataset[RawT]):
     ) -> None:
         super().__init__()
 
-        # upscales such that each element from each subdataset is seen at least once
         total_weight = sum(w for _, w in weighted_datasets)
         normalized_weights = [w / total_weight for _, w in weighted_datasets]
         scale = max(len(ds) / w for (ds, _), w in zip(weighted_datasets, normalized_weights))
 
         selected: list[HFDataset] = []
-        indices: list[tuple[int, int]] = []
 
-        for ds_idx, ((ds, _), w) in enumerate(zip(weighted_datasets, normalized_weights)):
+        for (ds, _), w in zip(weighted_datasets, normalized_weights):
             target_count = math.ceil(scale * w)
             ds_len = len(ds)
             upsampled = [i % ds_len for i in range(target_count)]
-
             selected.append(ds.ds.select(upsampled))
 
-            for i in range(target_count):
-                indices.append((ds_idx, i % ds_len))
-
         self._ds = concatenate_datasets(selected)
-        self._datasets = [ds for ds, _ in weighted_datasets]
-        self._indices = indices
 
     @property
     def ds(self) -> HFDataset:
         return self._ds
 
     def __getitem__(self, index: int) -> RawT:
-        ds_idx, item_idx = self._indices[index]
-        return self._datasets[ds_idx][item_idx]
+        return cast(RawT, self._ds[index])
 
     def __len__(self) -> int:
-        return len(self._indices)
+        return len(self.ds)


### PR DESCRIPTION
Closes #263 

What I (or rather Claude) did to test: Import the MixedDataset into a python script, verify that equal and unequal proportions work

test scripts:
```python
from mirror.datasets.mixed_dataset import MixedDataset
from mirror.datasets.txt_dataset import TxtDataset
import tempfile
import os

with tempfile.TemporaryDirectory() as tmpdir:
    # Create test files
    file1 = os.path.join(tmpdir, 'test1.txt')
    file2 = os.path.join(tmpdir, 'test2.txt')
    
    with open(file1, 'w') as f:
        f.write('a\nb\nc\n')  # 3 items
    
    with open(file2, 'w') as f:
        f.write('x\ny\n')  # 2 items
    
    ds1 = TxtDataset(file1)
    ds2 = TxtDataset(file2)
    
    # Test 1: Equal 50-50 split
    mixed = MixedDataset([(ds1, 1.0), (ds2, 1.0)])
    print(f'Test 1 (50-50): Mixed length={len(mixed)}')
    texts = [mixed[i]['text'] for i in range(len(mixed))]
    print(f'  Items: {texts}')
    print(f'  ds1 count: {sum(1 for t in texts if t in [\"a\", \"b\", \"c\"])}')
    print(f'  ds2 count: {sum(1 for t in texts if t in [\"x\", \"y\"])}')
    
    # Test 2: 90-10 split (ds1: 0.9, ds2: 0.1)
    mixed = MixedDataset([(ds1, 0.9), (ds2, 0.1)])
    print(f'\\nTest 2 (90-10): Mixed length={len(mixed)}')
    texts = [mixed[i]['text'] for i in range(len(mixed))]
    print(f'  Items: {texts}')
    ds1_count = sum(1 for t in texts if t in [\"a\", \"b\", \"c\"])
    ds2_count = sum(1 for t in texts if t in [\"x\", \"y\"])
    print(f'  ds1 count: {ds1_count} ({100*ds1_count/len(texts):.0f}%)')
    print(f'  ds2 count: {ds2_count} ({100*ds2_count/len(texts):.0f}%)')
    
    # Test 3: Check that every item appears at least once
    texts_flat = [mixed[i]['text'] for i in range(len(mixed))]
    print(f'\\nTest 3 (Complete coverage):')
    print(f'  \"a\" appears: {\"a\" in texts_flat}')
    print(f'  \"b\" appears: {\"b\" in texts_flat}')
    print(f'  \"c\" appears: {\"c\" in texts_flat}')
    print(f'  \"x\" appears: {\"x\" in texts_flat}')
    print(f'  \"y\" appears: {\"y\" in texts_flat}')
  ```

```python
source /etc/profile && mamba activate ./.env && python -c "
from mirror.datasets.mixed_dataset import MixedDataset
from mirror.datasets.txt_dataset import TxtDataset
import tempfile
import os

# Create two simple test datasets
with tempfile.TemporaryDirectory() as tmpdir:
    # Create test files
    file1 = os.path.join(tmpdir, 'test1.txt')
    file2 = os.path.join(tmpdir, 'test2.txt')
    
    with open(file1, 'w') as f:
        f.write('line1\nline2\nline3\n')
    
    with open(file2, 'w') as f:
        f.write('lineA\nlineB\n')
    
    # Create datasets
    ds1 = TxtDataset(file1)
    ds2 = TxtDataset(file2)
    
    print(f'Dataset 1 length: {len(ds1)}')
    print(f'Dataset 2 length: {len(ds2)}')
    
    # Create mixed dataset with equal weights
    mixed = MixedDataset([(ds1, 0.5), (ds2, 0.5)])
    
    print(f'Mixed dataset length: {len(mixed)}')
    print(f'First item: {mixed[0]}')
    print(f'Last item: {mixed[-1]}')
    print('✓ MixedDataset works!')
```