### PR TITLE
Add customizable wandb interval

### DIFF
--- a/docs/mirror onboarding/config-example.md
+++ b/docs/mirror onboarding/config-example.md
@@ -71,6 +71,7 @@ trainer:
         every_n_train_steps: null        # Save every N steps (null = only at start and end)
     - class_path: WandbCallback          # Customize Wandb output
       init_args:
+        log_every_n_steps: 1             # Log train metrics every N training steps
         extra_metrics_getter:
           class_path: GradNormMetrics
     - class_path: ConfigSnapshotCallback # Snapshot the config file alongside each checkpoint

--- a/docs/mirror onboarding/mirror onboarding.md
+++ b/docs/mirror onboarding/mirror onboarding.md
@@ -156,6 +156,8 @@ Future model interventions will be implemented in this module.
 
 By default, Wandb (`WandbCallback`) only logs `train/loss`, `val/loss`, and `test/loss`. To log additional per-step values to Wandb, pass an `ExtraMetricsGetter` into `WandbCallback`. An `ExtraMetricsGetter` is an abstract base class with a single method, `get_metrics(self, model: MirrorModel) -> dict`, which is called once per training step; whatever dict it returns is merged into that step's wandb log alongside `train/loss`.
 
+To change how often `train/loss` and any extra metrics are logged, pass `log_every_n_steps` (defaults to 1) to `WandbCallback`. 
+
 Subclasses live in `mirror/metrics/`. For example, `GradNormMetrics(ExtraMetricsGetter)` reads the model's gradients and returns `{"grad_norm": ...}`; to use it, you would [pass `WandbCallback(extra_metrics_getter=GradNormMetrics())` to the trainer's `callbacks=` list](config-example.md), which will override the default `WandbCallback`.
 
 ## Pipeline Developer Information

--- a/src/mirror/callbacks/wandb_callback.py
+++ b/src/mirror/callbacks/wandb_callback.py
@@ -25,10 +25,6 @@ class WandbCallback[RawT, ProcessedT, BatchT, ModelOutputT](
         log_every_n_steps: int = 1,
     ) -> None:
         super().__init__(is_singleton=True)
-        if log_every_n_steps < 1:
-            raise ValueError(
-                f"log_every_n_steps must be >= 1, got {log_every_n_steps}"
-            )
         self.run: WandbRun | None = None
         self.step = 0
         self.extra_metrics_getter = extra_metrics_getter
@@ -44,6 +40,8 @@ class WandbCallback[RawT, ProcessedT, BatchT, ModelOutputT](
         epochs: int,
         **kwargs,
     ):
+        self.step = 0
+
         if not fabric.is_global_zero:
             return
 
@@ -56,7 +54,6 @@ class WandbCallback[RawT, ProcessedT, BatchT, ModelOutputT](
             mode=self._mode(),
             dir=str(wandb_dir),
         )
-        self.step = 0
 
         self.run.config.update({
             "training_run_id": training_run_id,

--- a/src/mirror/callbacks/wandb_callback.py
+++ b/src/mirror/callbacks/wandb_callback.py
@@ -19,11 +19,20 @@ WandbMode = Literal["online", "offline"]
 class WandbCallback[RawT, ProcessedT, BatchT, ModelOutputT](
     Callback[RawT, ProcessedT, BatchT, ModelOutputT]
 ):
-    def __init__(self, extra_metrics_getter: ExtraMetricsGetter | None = None) -> None:
+    def __init__(
+        self,
+        extra_metrics_getter: ExtraMetricsGetter | None = None,
+        log_every_n_steps: int = 1,
+    ) -> None:
         super().__init__(is_singleton=True)
+        if log_every_n_steps < 1:
+            raise ValueError(
+                f"log_every_n_steps must be >= 1, got {log_every_n_steps}"
+            )
         self.run: WandbRun | None = None
         self.step = 0
         self.extra_metrics_getter = extra_metrics_getter
+        self.log_every_n_steps = log_every_n_steps
 
     def on_fit_start(
         self,
@@ -64,13 +73,15 @@ class WandbCallback[RawT, ProcessedT, BatchT, ModelOutputT](
         loss: float,
         **kwargs,
     ):
+        self.step += 1
+        if self.step % self.log_every_n_steps != 0:
+            return
         extra_metrics = (
             self.extra_metrics_getter.get_metrics(model, fabric)
             if self.extra_metrics_getter
             else {}
         )
         if self.run:
-            self.step += 1
             self.run.log({"train/loss": loss, **extra_metrics}, step=self.step)
 
     def on_validation_epoch_end(


### PR DESCRIPTION
Tested by running a standard training run with:
```yaml
trainer:
   callbacks:
      - class_path: WandbCallback
         init_args: 
            log_every_n_steps: 5
```
Then syncing wandb logs, checking on the website, and confirming that it only logged every 5 steps.
Closes #201 
