### PR TITLE
217 batched flatmap preprocessing

### DIFF
--- a/src/mirror/datasets/mirror_dataset.py
+++ b/src/mirror/datasets/mirror_dataset.py
@@ -22,14 +22,26 @@ class MirrorDataset[RawT](Dataset[RawT], Sized):
 
 def preprocess_dataset[RawT, ProcessedT](
     dataset: MirrorDataset[RawT],
-    preprocessor_function: Callable[[RawT], ProcessedT],
+    preprocessor_function: Callable[[RawT], Sequence[ProcessedT]],
     num_nodes: int,
 ) -> Sequence[ProcessedT]:
-    def mappable_preprocessor_function(row: dict) -> dict:
-        return {"input_ids": preprocessor_function(dataset.to_row_type(row))}
+    column_names = dataset.ds.column_names
+
+    def mappable_preprocessor_function(batch: dict) -> dict:
+        n = len(next(iter(batch.values())))
+        outputs = []
+        for i in range(n):
+            row = {k: batch[k][i] for k in column_names}
+            outputs.extend(preprocessor_function(dataset.to_row_type(row)))
+        return {"input_ids": outputs}
 
     with _ds_cache_path_context():
-        mapped = dataset.ds.map(mappable_preprocessor_function, num_proc=num_nodes)
+        mapped = dataset.ds.map(
+            mappable_preprocessor_function,
+            num_proc=num_nodes,
+            batched=True,
+            remove_columns=column_names,
+        )
 
     print("Preprocessing complete.", file=stderr)
     mapped.set_format(type="torch", columns=["input_ids"])

--- a/src/mirror/datasets/on_demand_preprocessed_dataset.py
+++ b/src/mirror/datasets/on_demand_preprocessed_dataset.py
@@ -14,7 +14,6 @@ class OnDemandPreprocessedDataset[RawT, ProcessedT](Dataset[ProcessedT]):
         super().__init__()
         self.raw_dataset = raw_dataset
         self.preprocess = preprocess
-        # cumulative_lengths[i] = total processed items produced by raw_dataset[:i+1]
         cumulative = 0
         self._cumulative_lengths: list[int] = []
         for i in range(len(raw_dataset)):

--- a/src/mirror/datasets/on_demand_preprocessed_dataset.py
+++ b/src/mirror/datasets/on_demand_preprocessed_dataset.py
@@ -1,22 +1,31 @@
 from __future__ import annotations
-from typing import Callable
+from bisect import bisect_right
+from typing import Callable, Sequence
 from torch.utils.data import Dataset
 
 from mirror.datasets.mirror_dataset import MirrorDataset
 
 class OnDemandPreprocessedDataset[RawT, ProcessedT](Dataset[ProcessedT]):
     def __init__(
-            self, 
-            raw_dataset: MirrorDataset[RawT], 
-            preprocess: Callable[[RawT], ProcessedT]
+            self,
+            raw_dataset: MirrorDataset[RawT],
+            preprocess: Callable[[RawT], Sequence[ProcessedT]]
     ):
         super().__init__()
         self.raw_dataset = raw_dataset
         self.preprocess = preprocess
+        # cumulative_lengths[i] = total processed items produced by raw_dataset[:i+1]
+        cumulative = 0
+        self._cumulative_lengths: list[int] = []
+        for i in range(len(raw_dataset)):
+            cumulative += len(preprocess(raw_dataset[i]))
+            self._cumulative_lengths.append(cumulative)
 
     def __len__(self) -> int:
-        return len(self.raw_dataset)
+        return self._cumulative_lengths[-1] if self._cumulative_lengths else 0
 
     def __getitem__(self, index: int) -> ProcessedT:
-        return self.preprocess(self.raw_dataset[index])
-        
+        raw_index = bisect_right(self._cumulative_lengths, index)
+        prev = self._cumulative_lengths[raw_index - 1] if raw_index > 0 else 0
+        sub_index = index - prev
+        return self.preprocess(self.raw_dataset[raw_index])[sub_index]

--- a/src/mirror/preprocessors/bpe_preprocessor.py
+++ b/src/mirror/preprocessors/bpe_preprocessor.py
@@ -46,13 +46,13 @@ class BPEPreprocessor(
             pad_token="<pad>",
         )
 
-    def preprocess_example(self, example: TextRow) -> TokenTensor:
+    def preprocess_example(self, example: TextRow) -> list[TokenTensor]:
         encoding = self._raw_tokenizer.encode(example['text'], add_special_tokens=True)
         ids = encoding.ids
         if len(ids) < 2:
             eos = self._raw_tokenizer.token_to_id("</s>")
             ids = [eos, eos] if len(ids) == 0 else [*ids, eos]
-        return cast(TokenTensor, ids)
+        return [cast(TokenTensor, ids)]
 
     def collate(self, examples: list[TokenTensor]) -> tuple[TokenBatch, AttentionMaskBatch]:
         return collate_tokens(self._tokenizer, examples)

--- a/src/mirror/preprocessors/mirror_gpt_preprocessor.py
+++ b/src/mirror/preprocessors/mirror_gpt_preprocessor.py
@@ -18,7 +18,7 @@ class MirrorGPTPreprocessor(
             self._tokenizer.pad_token = self._tokenizer.eos_token
         self._max_length = max_length
 
-    def preprocess_example(self, example: TextRow) -> TokenTensor:
+    def preprocess_example(self, example: TextRow) -> list[TokenTensor]:
         ids = self._tokenizer.encode(
             example['text'],
             add_special_tokens=True,
@@ -28,7 +28,7 @@ class MirrorGPTPreprocessor(
         if len(ids) < 2:
             eos = self._tokenizer.eos_token_id
             ids = [eos, eos] if len(ids) == 0 else [*ids, eos] # GPT causal LM loss shifts labels by 1, so seq_len=1 produces zero training targets
-        return cast(TokenTensor, ids)
+        return [cast(TokenTensor, ids)]
 
     def collate(self, examples: list[TokenTensor]) -> tuple[TokenBatch, AttentionMaskBatch]:
         return collate_tokens(self._tokenizer, examples)

--- a/src/mirror/preprocessors/mirror_llama_preprocessor.py
+++ b/src/mirror/preprocessors/mirror_llama_preprocessor.py
@@ -16,7 +16,7 @@ class MirrorLlamaPreprocessor(
             self._tokenizer.pad_token = self._tokenizer.eos_token
         self._max_length = max_length
 
-    def preprocess_example(self, example: TextRow) -> TokenTensor:
+    def preprocess_example(self, example: TextRow) -> list[TokenTensor]:
         ids = self._tokenizer.encode(
             example['text'],
             add_special_tokens=True,
@@ -26,7 +26,7 @@ class MirrorLlamaPreprocessor(
         if len(ids) < 2:
             eos = self._tokenizer.eos_token_id
             ids = [eos, eos] if len(ids) == 0 else [*ids, eos]
-        return cast(TokenTensor, ids)
+        return [cast(TokenTensor, ids)]
 
     def collate(self, examples: list[TokenTensor]) -> tuple[TokenBatch, AttentionMaskBatch]:
         return collate_tokens(self._tokenizer, examples)

--- a/src/mirror/preprocessors/mirror_preprocessor.py
+++ b/src/mirror/preprocessors/mirror_preprocessor.py
@@ -1,9 +1,10 @@
 from abc import ABC, abstractmethod
+from typing import Sequence
 
 
 class MirrorPreprocessor[RawT, ProcessedT, BatchT](ABC):
     @abstractmethod
-    def preprocess_example(self, example: RawT) -> ProcessedT:
+    def preprocess_example(self, example: RawT) -> Sequence[ProcessedT]:
         pass
 
     @abstractmethod

--- a/src/mirror/preprocessors/placeholder_preprocessor.py
+++ b/src/mirror/preprocessors/placeholder_preprocessor.py
@@ -9,8 +9,8 @@ from mirror.types import AttentionMaskBatch, TextRow, TokenBatch, TokenTensor
 class PlaceholderPreprocessor(
     MirrorPreprocessor[TextRow, TokenTensor, tuple[TokenBatch, AttentionMaskBatch]]
 ):
-    def preprocess_example(self, example: TextRow) -> TokenTensor:
-        return [1, 2, 3, 4]
+    def preprocess_example(self, example: TextRow) -> list[TokenTensor]:
+        return [[1, 2, 3, 4]]
     
     def collate(self, examples: list[TokenTensor]) -> tuple[TokenBatch, AttentionMaskBatch]:
         tokens = cast(TokenBatch, torch.tensor([[1, 2, 3, 4]] * len(examples), device=get_device()))


### PR DESCRIPTION
Tested using this Claude script:
```
cd /home/jansen05/MIRROR-Pipeline

PYTHONPATH=src .env/bin/python <<'EOF'
from datasets import Dataset as HFDataset
from mirror.datasets.mirror_dataset import preprocess_dataset
from mirror.datasets.on_demand_preprocessed_dataset import OnDemandPreprocessedDataset

class FakeDS:
    def __init__(self, ds): self._ds = ds
    @property
    def ds(self): return self._ds
    def to_row_type(self, row): return row['text']
    def __len__(self): return len(self._ds)
    def __getitem__(self, i): return self.to_row_type(self._ds[i])

raw = HFDataset.from_dict({'text': ['hello world', 'foo bar', 'baz']})
ds = FakeDS(raw)

one_to_one = lambda t: [list(t.encode())]
flatmap    = lambda t: [[1, len(t)], [2, len(t)]]

print('--- preprocess_dataset ---')
print('1:1 len:', len(preprocess_dataset(ds, one_to_one, num_nodes=1)), '(expected 3)')
out = preprocess_dataset(ds, flatmap, num_nodes=1)
print('flatmap len:', len(out), '(expected 6)')
print('flatmap [0]:', out[0].tolist(), '  [1]:', out[1].tolist())

print('--- OnDemandPreprocessedDataset ---')
od1 = OnDemandPreprocessedDataset(ds, one_to_one)
print('1:1 len:', len(od1), '  sample:', od1[0])
odf = OnDemandPreprocessedDataset(ds, flatmap)
print('flatmap len:', len(odf), '  [5]:', odf[5], '(expected [2, 3])')
EOF
```
And confirming that the output was:
```
1:1 len: 3, flatmap len: 6, OD flatmap len: 6, [5]: [2, 3]
```

Closes #217 