### PR TITLE
Extract Dataloader construction method

### DIFF
--- a/src/mirror/trainer.py
+++ b/src/mirror/trainer.py
@@ -107,7 +107,10 @@ class Trainer[RawT, ProcessedT, BatchT, ModelOutputT]:
         )
 
 
-        dataloader = self._make_dataloader(dataset, preprocessor, batch_size, do_preprocess, shuffle)
+        dataloader = make_dataloader(
+            dataset, preprocessor, batch_size, do_preprocess, shuffle,
+            num_nodes=self.num_nodes, fabric=self.fabric,
+        )
 
         start_epoch = 0
         start_batch = 0
@@ -140,11 +143,17 @@ class Trainer[RawT, ProcessedT, BatchT, ModelOutputT]:
 
         val_dataloader = None
         if val_dataset is not None:
-            val_dataloader = self._make_dataloader(val_dataset, preprocessor, batch_size, do_preprocess, False)
+            val_dataloader = make_dataloader(
+                val_dataset, preprocessor, batch_size, do_preprocess, False,
+                num_nodes=self.num_nodes, fabric=self.fabric,
+            )
 
         test_dataloader = None
         if test_dataset is not None:
-            test_dataloader = self._make_dataloader(test_dataset, preprocessor, batch_size, do_preprocess, False)
+            test_dataloader = make_dataloader(
+                test_dataset, preprocessor, batch_size, do_preprocess, False,
+                num_nodes=self.num_nodes, fabric=self.fabric,
+            )
 
         self.fabric.call('on_fit_start', fabric=self.fabric, model=model, optimizer=optimizer, dataset=dataset,
             training_run_id=training_run_id, n_batches=n_batches, epochs=epochs, start_epoch=start_epoch,
@@ -217,20 +226,6 @@ class Trainer[RawT, ProcessedT, BatchT, ModelOutputT]:
             return 0.0
         return total_loss / n_batches
 
-    def _make_dataloader(self, dataset, preprocessor, batch_size, do_preprocess, shuffle):
-        if do_preprocess:
-            preprocessed = preprocess_dataset(dataset, preprocessor.preprocess_example, self.num_nodes)
-        else:
-            preprocessed = OnDemandPreprocessedDataset(dataset, preprocessor.preprocess_example)
-        dataloader = DataLoader(
-            cast(Dataset, preprocessed),
-            batch_size=batch_size,
-            collate_fn=preprocessor.collate,
-            drop_last=False,
-            shuffle=shuffle,
-        )
-        return self.fabric.setup_dataloaders(dataloader, move_to_device=self.config['device'] == 'cuda')
-
     def _make_fabric(self, strategy: Strategy, accelerator: str) -> Fabric:
         return Fabric(
             strategy=strategy,
@@ -241,11 +236,39 @@ class Trainer[RawT, ProcessedT, BatchT, ModelOutputT]:
         )
 
 def separate_singletons[RawT, ProcessedT, BatchT, ModelOutputT](
-       callbacks: List[Callback[RawT, ProcessedT, BatchT, ModelOutputT]]
+        callbacks: List[Callback[RawT, ProcessedT, BatchT, ModelOutputT]]
 ) -> tuple[
-   List[Callback[RawT, ProcessedT, BatchT, ModelOutputT]],
-   List[Callback[RawT, ProcessedT, BatchT, ModelOutputT]]
+        List[Callback[RawT, ProcessedT, BatchT, ModelOutputT]],
+        List[Callback[RawT, ProcessedT, BatchT, ModelOutputT]]
 ]:
     singletons = [c for c in callbacks if c.is_singleton]
     non_singletons = [c for c in callbacks if not c.is_singleton]
     return singletons, non_singletons
+
+
+def make_dataloader[RawT, ProcessedT, BatchT](
+        dataset: MirrorDataset[RawT],
+        preprocessor: MirrorPreprocessor[RawT, ProcessedT, BatchT],
+        batch_size: int,
+        do_preprocess: bool,
+        shuffle: bool,
+        num_nodes: int = 1,
+        fabric: Fabric | None = None,
+) -> DataLoader:
+    if do_preprocess:
+        preprocessed = preprocess_dataset(dataset, preprocessor.preprocess_example, num_nodes)
+    else:
+        preprocessed = OnDemandPreprocessedDataset(dataset, preprocessor.preprocess_example)
+    dataloader = DataLoader(
+        cast(Dataset, preprocessed),
+        batch_size=batch_size,
+        collate_fn=preprocessor.collate,
+        drop_last=False,
+        shuffle=shuffle,
+    )
+    if fabric is None:
+        return dataloader
+    return cast(
+        DataLoader, 
+        fabric.setup_dataloaders(dataloader, move_to_device=get_config()['device'] == 'cuda')
+    )

--- a/src/mirror/trainer.py
+++ b/src/mirror/trainer.py
@@ -107,10 +107,8 @@ class Trainer[RawT, ProcessedT, BatchT, ModelOutputT]:
         )
 
 
-        dataloader = make_dataloader(
-            dataset, preprocessor, batch_size, do_preprocess, shuffle,
-            num_nodes=self.num_nodes, fabric=self.fabric,
-        )
+        dataloader = make_dataloader(dataset, preprocessor, batch_size, do_preprocess,
+                                    shuffle, num_nodes=self.num_nodes, fabric=self.fabric)
 
         start_epoch = 0
         start_batch = 0
@@ -143,22 +141,18 @@ class Trainer[RawT, ProcessedT, BatchT, ModelOutputT]:
 
         val_dataloader = None
         if val_dataset is not None:
-            val_dataloader = make_dataloader(
-                val_dataset, preprocessor, batch_size, do_preprocess, False,
-                num_nodes=self.num_nodes, fabric=self.fabric,
-            )
+            val_dataloader = make_dataloader(val_dataset, preprocessor, batch_size, do_preprocess,
+                                             False, num_nodes=self.num_nodes, fabric=self.fabric)
 
         test_dataloader = None
         if test_dataset is not None:
-            test_dataloader = make_dataloader(
-                test_dataset, preprocessor, batch_size, do_preprocess, False,
-                num_nodes=self.num_nodes, fabric=self.fabric,
-            )
+            test_dataloader = make_dataloader(test_dataset, preprocessor, batch_size, do_preprocess,
+                                              False, num_nodes=self.num_nodes, fabric=self.fabric)
 
-        self.fabric.call('on_fit_start', fabric=self.fabric, model=model, optimizer=optimizer, dataset=dataset,
-            training_run_id=training_run_id, n_batches=n_batches, epochs=epochs, start_epoch=start_epoch,
-            start_batch=start_batch, run_config_yaml=run_config_yaml,
-            batch_size=batch_size, num_nodes=self.num_nodes)
+        self.fabric.call('on_fit_start', fabric=self.fabric, model=model, optimizer=optimizer, 
+                         dataset=dataset, training_run_id=training_run_id, n_batches=n_batches, 
+                         epochs=epochs, start_epoch=start_epoch, start_batch=start_batch, 
+                         run_config_yaml=run_config_yaml, batch_size=batch_size, num_nodes=self.num_nodes)
 
         try:
             for epoch_idx in range(start_epoch, epochs):
@@ -180,18 +174,9 @@ class Trainer[RawT, ProcessedT, BatchT, ModelOutputT]:
 
                     global_step = epoch_idx * n_batches + batch_idx
 
-                    self.fabric.call(
-                        'on_train_batch_end',
-                        fabric=self.fabric,
-                        model=model,
-                        optimizer=optimizer,
-                        loss=loss_value,
-                        training_run_id=training_run_id,
-                        epochs=epochs,
-                        n_batches=n_batches,
-                        batch_idx=batch_idx,
-                        global_step = global_step,
-                    )
+                    self.fabric.call('on_train_batch_end', fabric=self.fabric, model=model, optimizer=optimizer,
+                                     loss=loss_value, training_run_id=training_run_id, epochs=epochs, 
+                                     n_batches=n_batches, batch_idx=batch_idx, global_step = global_step)
 
                 if val_dataloader is not None and (epoch_idx + 1) % val_check_interval == 0:
                     val_loss = self._eval_loop(model, val_dataloader)


### PR DESCRIPTION
Tested by running the following script:
```
import torch
from datasets import Dataset as HFDataset
from lightning import Fabric
from lightning.fabric.strategies.single_device import SingleDeviceStrategy
from torch.utils.data import DataLoader

from mirror.config import init_config
from mirror.datasets.mirror_dataset import MirrorDataset
from mirror.preprocessors.mirror_preprocessor import MirrorPreprocessor
from mirror.trainer import make_dataloader


class TinyDataset(MirrorDataset[int]):
    def __init__(self, values: list[int]) -> None:
        self._ds = HFDataset.from_list([{"x": v} for v in values])

    @property
    def ds(self) -> HFDataset:
        return self._ds

    def to_row_type(self, ds_row: dict) -> int:
        return ds_row["x"]

    def __len__(self) -> int:
        return len(self._ds)


class TinyPreprocessor(MirrorPreprocessor[int, torch.Tensor, torch.Tensor]):
    def preprocess_example(self, example: int) -> torch.Tensor:
        return torch.tensor([example])

    def collate(self, examples: list[torch.Tensor]) -> torch.Tensor:
        return torch.stack(examples)


def test_without_fabric_returns_plain_dataloader() -> None:
    dataset = TinyDataset([1, 2, 3, 4])
    preprocessor = TinyPreprocessor()
    dl = make_dataloader(dataset, preprocessor, batch_size=2,
                         do_preprocess=False, shuffle=False)
    assert isinstance(dl, DataLoader)
    batches = list(dl)
    assert len(batches) == 2
    assert torch.equal(batches[0], torch.tensor([[1], [2]]))
    assert torch.equal(batches[1], torch.tensor([[3], [4]]))


def test_with_fabric_wraps_dataloader() -> None:
    dataset = TinyDataset([10, 20, 30, 40])
    preprocessor = TinyPreprocessor()
    fabric = Fabric(strategy=SingleDeviceStrategy(device="cpu"), accelerator="cpu", devices=1)
    fabric.launch()
    dl = make_dataloader(dataset, preprocessor, batch_size=2,
                         do_preprocess=False, shuffle=False, fabric=fabric)
    plain = make_dataloader(dataset, preprocessor, batch_size=2,
                            do_preprocess=False, shuffle=False)
    assert type(dl) is not type(plain)
    batches = list(dl)
    assert len(batches) == 2
    assert torch.equal(batches[0], torch.tensor([[10], [20]]))


if __name__ == "__main__":
    init_config(device="cpu")
    test_without_fabric_returns_plain_dataloader()
    print("PASS: without fabric returns plain DataLoader")
    test_with_fabric_wraps_dataloader()
    print("PASS: with fabric returns wrapped DataLoader")
```
Closes #214 