### PR TITLE
Implement L2 Norm weight tracking

### DIFF
--- a/src/mirror/metrics/__init__.py
+++ b/src/mirror/metrics/__init__.py
@@ -1,2 +1,3 @@
 from mirror.metrics.extra_metrics_getter import ExtraMetricsGetter
 from mirror.metrics.grad_norm_metrics import GradNormMetrics
+from mirror.metrics.l2_norm_metrics import L2NormMetrics

--- a/src/mirror/metrics/l2_norm_metrics.py
+++ b/src/mirror/metrics/l2_norm_metrics.py
@@ -1,0 +1,18 @@
+from typing import cast
+
+import torch
+from lightning import Fabric
+
+from mirror.metrics.extra_metrics_getter import ExtraMetricsGetter
+from mirror.models.mirror_model import MirrorModel
+
+
+class L2NormMetrics(ExtraMetricsGetter):
+    def get_metrics(self, model: MirrorModel, fabric: Fabric) -> dict:
+        params = [p.detach() for p in model.parameters()]
+        if not params:
+            return {"weight_norm": 0.0}
+        per_param_norms = torch.stack([torch.linalg.vector_norm(p) for p in params])
+        local_sq = per_param_norms.pow(2).sum()
+        global_sq = cast(torch.Tensor, fabric.all_reduce(local_sq, reduce_op="sum"))
+        return {"weight_norm": global_sq.sqrt().item()}

--- a/src/mirror/metrics/l2_norm_metrics.py
+++ b/src/mirror/metrics/l2_norm_metrics.py
@@ -11,8 +11,8 @@ class L2NormMetrics(ExtraMetricsGetter):
     def get_metrics(self, model: MirrorModel, fabric: Fabric) -> dict:
         params = [p.detach() for p in model.parameters()]
         if not params:
-            return {"weight_norm": 0.0}
+            return {"l2_norm": 0.0}
         per_param_norms = torch.stack([torch.linalg.vector_norm(p) for p in params])
         local_sq = per_param_norms.pow(2).sum()
         global_sq = cast(torch.Tensor, fabric.all_reduce(local_sq, reduce_op="sum"))
-        return {"weight_norm": global_sq.sqrt().item()}
+        return {"l2_norm": global_sq.sqrt().item()}


### PR DESCRIPTION
Tested by running a training run with:
```yaml
trainer:
  num_nodes: 1
  callbacks:
    - class_path: WandbCallback
      init_args:
        log_every_n_steps: 5
        extra_metrics_getter:
          class_path: L2NormMetrics
```

And confirming that L2 norm metrics are tracked by wandb in the output (& the outputs are sane).

Closes #267 