### PR TITLE
Implement list-acceptance for metrics

### DIFF
--- a/src/mirror/callbacks/wandb_callback.py
+++ b/src/mirror/callbacks/wandb_callback.py
@@ -21,13 +21,13 @@ class WandbCallback[RawT, ProcessedT, BatchT, ModelOutputT](
 ):
     def __init__(
         self,
-        extra_metrics_getter: ExtraMetricsGetter | None = None,
+        extra_metrics_getters: list[ExtraMetricsGetter] = [],
         log_every_n_steps: int = 1,
     ) -> None:
         super().__init__(is_singleton=True)
         self.run: WandbRun | None = None
         self.step = 0
-        self.extra_metrics_getter = extra_metrics_getter
+        self.extra_metrics_getters = extra_metrics_getters
         self.log_every_n_steps = log_every_n_steps
 
     def on_fit_start(
@@ -73,11 +73,11 @@ class WandbCallback[RawT, ProcessedT, BatchT, ModelOutputT](
         self.step += 1
         if self.step % self.log_every_n_steps != 0:
             return
-        extra_metrics = (
-            self.extra_metrics_getter.get_metrics(model, fabric)
-            if self.extra_metrics_getter
-            else {}
-        )
+        extra_metrics = {
+            k: v
+            for getter in self.extra_metrics_getters
+            for k, v in getter.get_metrics(model, fabric).items()
+        }
         if self.run:
             self.run.log({"train/loss": loss, **extra_metrics}, step=self.step)
 


### PR DESCRIPTION
Tested by doing training runs with a single metric and with multiple metrics (I had Claude make me a dummy metric to use alongside GradNorm since L2Norm hasn't been merged yet) and confirmed that both work.
```yaml
trainer:
  num_nodes: 1
  callbacks:
    - class_path: WandbCallback
      init_args:
        log_every_n_steps: 5
        extra_metrics_getters:
          - class_path: GradNormMetrics
          # - class_path: DummyMetrics
```
Closes #310 