### PR TITLE
Add nvidia-smi to slurm template

### DIFF
--- a/src/mirror/templates/slurm.jinja
+++ b/src/mirror/templates/slurm.jinja
@@ -17,4 +17,6 @@
 
 {{ activate_cmd }}
 
+nvidia-smi
+
 {{ run_cmd }}


### PR DESCRIPTION
Tested by submitting SLURM job and confirming that GPU information is logged in the output file
Closes #153 