### PR TITLE
334 bug scheduler reconstructed out of sync when resuming from checkpoint

### DIFF
--- a/src/mirror/trainer.py
+++ b/src/mirror/trainer.py
@@ -150,6 +150,10 @@ class Trainer[RawT, ProcessedT, BatchT, ModelOutputT]:
         if configure_scheduler is not None:
             total_training_steps = epochs * len(dataloader)
             scheduler = configure_scheduler(optimizer, total_training_steps)
+            if global_step > 0: # Set optimizer._opt_called to reflect checkpoint resuming 
+                optimizer._opt_called = True  # type: ignore[attr-defined]
+                for _ in range(global_step):
+                    scheduler.step()
 
         val_dataloader = None
         if val_dataset is not None:

--- a/src/mirror/trainer.py
+++ b/src/mirror/trainer.py
@@ -150,7 +150,7 @@ class Trainer[RawT, ProcessedT, BatchT, ModelOutputT]:
         if configure_scheduler is not None:
             total_training_steps = epochs * len(dataloader)
             scheduler = configure_scheduler(optimizer, total_training_steps)
-            if global_step > 0: # Set optimizer._opt_called to reflect checkpoint resuming 
+            if global_step > 0: # Resuming from checkpoint
                 optimizer._opt_called = True  # type: ignore[attr-defined]
                 for _ in range(global_step):
                     scheduler.step()


### PR DESCRIPTION
Tested by running the following script:
```bash
PYTHONPATH=src .env/bin/python -W error::UserWarning -c "
import torch, torch.nn as nn
from mirror.schedulers.cosine_annealing_scheduler import CosineAnnealingScheduler
m = nn.Linear(2, 1)
opt = torch.optim.SGD(m.parameters(), lr=1.0)
sched = CosineAnnealingScheduler()(opt, total_training_steps=100)
global_step = 50
if global_step > 0:
    opt._opt_called = True
    for _ in range(global_step):
        sched.step()
print(f'after fast-forward LR: {opt.param_groups[0][\"lr\"]:.6f}')
loss = m(torch.randn(1, 2)).sum()
loss.backward()
opt.step()
sched.step()
print(f'after one real step LR: {opt.param_groups[0][\"lr\"]:.6f}')
print('no warning raised')
"
```

Closes #334 