### PR TITLE
345 use preprocessed typeddatasets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "jsonargparse==4.42.0",
     "lightning==2.5.5",
     "transformers==5.2.0",
+    "typed-datasets @ git+https://github.com/Plyb/typed-datasets.git",
     "tqdm==4.67.1",
     "matplotlib==3.10.9",
     "wandb",

--- a/src/mirror/callbacks/callback.py
+++ b/src/mirror/callbacks/callback.py
@@ -1,10 +1,11 @@
+from typing import Any, Mapping
 from lightning import Fabric
 from torch.optim import Optimizer
 from mirror.datasets.mirror_dataset import MirrorDataset
 from mirror.models.mirror_model import MirrorModel
 
 
-class Callback[RawT, ProcessedT, BatchT, ModelOutputT]:
+class Callback[RawT: Mapping[str, Any], ProcessedT, BatchT, ModelOutputT]:
     """
     The names of the methods here are based on those of Lightning's
     Callback class: https://lightning.ai/docs/pytorch/stable/api/lightning.pytorch.callbacks.Callback.html#lightning.pytorch.callbacks.Callback

--- a/src/mirror/callbacks/checkpoint_callback.py
+++ b/src/mirror/callbacks/checkpoint_callback.py
@@ -1,4 +1,4 @@
-from typing import cast, Any
+from typing import cast, Any, Mapping
 from lightning import Fabric
 from torch.nn import Module
 from torch.optim import Optimizer
@@ -7,7 +7,7 @@ from mirror.checkpoint_identifier import CheckpointIdentifier
 from mirror.models.mirror_model import MirrorModel
 from mirror.dict_types import StateDict
 
-class CheckpointCallback[RawT, ProcessedT, BatchT, ModelOutputT](
+class CheckpointCallback[RawT: Mapping[str, Any], ProcessedT, BatchT, ModelOutputT](
        Callback[RawT, ProcessedT, BatchT, ModelOutputT]
 ):
     def __init__(self, every_n_training_steps: int | None = None) -> None:

--- a/src/mirror/callbacks/config_snapshot_callback.py
+++ b/src/mirror/callbacks/config_snapshot_callback.py
@@ -1,10 +1,11 @@
 from pathlib import Path
 import subprocess, json, datetime, socket, os
+from typing import Any, Mapping
 from lightning import Fabric
 from mirror.callbacks.callback import Callback
 from mirror.util import safe_training_run_path
 
-class ConfigSnapshotCallback[RawT, ProcessedT, BatchT, ModelOutputT](
+class ConfigSnapshotCallback[RawT: Mapping[str, Any], ProcessedT, BatchT, ModelOutputT](
        Callback[RawT, ProcessedT, BatchT, ModelOutputT]
 ):
     is_singleton = True

--- a/src/mirror/callbacks/print_step_callback.py
+++ b/src/mirror/callbacks/print_step_callback.py
@@ -1,7 +1,8 @@
+from typing import Any, Mapping
 from mirror.callbacks.callback import Callback
 
 
-class PrintStepCallback[RawT, ProcessedT, BatchT, ModelOutputT](
+class PrintStepCallback[RawT: Mapping[str, Any], ProcessedT, BatchT, ModelOutputT](
     Callback[RawT, ProcessedT, BatchT, ModelOutputT]
 ):
     def on_train_batch_end(

--- a/src/mirror/callbacks/progress_callback.py
+++ b/src/mirror/callbacks/progress_callback.py
@@ -1,8 +1,9 @@
+from typing import Any, Mapping
 from lightning import Fabric
 from tqdm import tqdm
 from mirror.callbacks.callback import Callback
 
-class ProgressCallback[RawT, ProcessedT, BatchT, ModelOutputT](
+class ProgressCallback[RawT: Mapping[str, Any], ProcessedT, BatchT, ModelOutputT](
        Callback[RawT, ProcessedT, BatchT, ModelOutputT]
 ):
     def __init__(self, bar_refresh_interval: int = 5) -> None:

--- a/src/mirror/callbacks/test_callback.py
+++ b/src/mirror/callbacks/test_callback.py
@@ -1,6 +1,7 @@
+from typing import Any, Mapping
 from mirror.callbacks.callback import Callback
 
-class TestCallback[RawT, ProcessedT, BatchT, ModelOutputT](
+class TestCallback[RawT: Mapping[str, Any], ProcessedT, BatchT, ModelOutputT](
        Callback[RawT, ProcessedT, BatchT, ModelOutputT]
 ):
     def __init__(self, is_singleton = False, test_variable: bool = False) -> None: 

--- a/src/mirror/callbacks/timer_callback.py
+++ b/src/mirror/callbacks/timer_callback.py
@@ -4,7 +4,7 @@ import sys
 import time
 from pathlib import Path
 from types import FrameType
-from typing import Literal, TypedDict, cast
+from typing import Any, Literal, Mapping, TypedDict, cast
 
 import torch
 from torch import Tensor
@@ -50,7 +50,7 @@ def benchmark_lock_path(lock_dir: Path, num_nodes: int, devices_per_node: int, b
     return lock_dir / f"{benchmark_run_key(num_nodes, devices_per_node, batch_size, param_count)}.lock"
 
 
-class TimerCallback[RawT, ProcessedT, BatchT, ModelOutputT](
+class TimerCallback[RawT: Mapping[str, Any], ProcessedT, BatchT, ModelOutputT](
     Callback[RawT, ProcessedT, BatchT, ModelOutputT]
 ):
     def __init__(

--- a/src/mirror/callbacks/wandb_callback.py
+++ b/src/mirror/callbacks/wandb_callback.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Any, Literal, Mapping
 import os
 
 import wandb
@@ -16,7 +16,7 @@ from wandb.sdk.wandb_run import Run as WandbRun
 WandbMode = Literal["online", "offline"]
 
 
-class WandbCallback[RawT, ProcessedT, BatchT, ModelOutputT](
+class WandbCallback[RawT: Mapping[str, Any], ProcessedT, BatchT, ModelOutputT](
     Callback[RawT, ProcessedT, BatchT, ModelOutputT]
 ):
     def __init__(

--- a/src/mirror/datasets/dataset_util.py
+++ b/src/mirror/datasets/dataset_util.py
@@ -9,8 +9,13 @@ from mirror.util import is_compute_node
 
 from mirror.download_util import assert_can_download
 from mirror.util import mirror_data_path
+from mirror.types import TextRow
 
 datasets_path = mirror_data_path / 'datasets'
+
+
+def to_text_row(row: TextRow) -> TextRow:
+    return TextRow(text=row['text'])
 
 
 def load_hf_dataset(

--- a/src/mirror/datasets/dataset_util.py
+++ b/src/mirror/datasets/dataset_util.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 from sys import stderr
-from typing import Callable, Sequence
+from typing import Any, Callable, Mapping, Sequence
 from pathlib import Path
 
 from datasets import Dataset, DatasetDict, load_dataset, load_from_disk
@@ -14,7 +14,7 @@ from mirror.types import TextRow
 datasets_path = mirror_data_path / 'datasets'
 
 
-def to_text_row(row: TextRow) -> TextRow:
+def just_text_row(row: Mapping[str, Any]) -> TextRow:
     return TextRow(text=row['text'])
 
 

--- a/src/mirror/datasets/dataset_util.py
+++ b/src/mirror/datasets/dataset_util.py
@@ -1,7 +1,7 @@
 import os
 import shutil
 from sys import stderr
-from typing import Any, Callable, Mapping, Sequence
+from typing import Callable, Sequence
 from pathlib import Path
 
 from datasets import Dataset, DatasetDict, load_dataset, load_from_disk
@@ -14,7 +14,7 @@ from mirror.types import TextRow
 datasets_path = mirror_data_path / 'datasets'
 
 
-def just_text_row(row: Mapping[str, Any]) -> TextRow:
+def just_text_row(row: TextRow) -> TextRow:
     return TextRow(text=row['text'])
 
 

--- a/src/mirror/datasets/fineweb_dataset.py
+++ b/src/mirror/datasets/fineweb_dataset.py
@@ -1,10 +1,10 @@
-from typing import Literal, cast
+from typing import Literal, TypedDict, cast
 
 import numpy as np
 from datasets import DatasetDict
 from typed_datasets import TypedDataset
 
-from mirror.datasets.dataset_util import load_hf_dataset, to_text_row
+from mirror.datasets.dataset_util import load_hf_dataset, just_text_row
 from mirror.datasets.mirror_dataset import MirrorDataset
 from mirror.types import TextRow
 from mirror.util import _ds_cache_path_context
@@ -12,6 +12,19 @@ from mirror.util import _ds_cache_path_context
 hf_dataset_path = 'HuggingFaceFW/fineweb-edu'
 hf_dataset_name = 'sample-10BT'
 target_token_count = 2_000_000_000
+
+
+class FinewebRow(TypedDict):
+    text: str
+    id: str
+    dump: str
+    url: str
+    file_path: str
+    language: str
+    language_score: float
+    token_count: int
+    score: float
+    int_score: int
 
 
 class FinewebDataset(MirrorDataset[TextRow]):
@@ -28,20 +41,20 @@ class FinewebDataset(MirrorDataset[TextRow]):
         super().__init__()
 
         raw = cast(DatasetDict, load_hf_dataset(hf_dataset_path, hf_dataset_name))[split]
-        typed: TypedDataset[TextRow] = self._truncate(TypedDataset(raw))
+        ds = self._truncate(TypedDataset[FinewebRow](raw))
 
         if skip:
-            typed = typed.skip(skip)
+            ds = ds.skip(skip)
         if head:
-            typed = typed.take(head)
+            ds = ds.take(head)
 
         with _ds_cache_path_context():
-            self._ds = typed.map(to_text_row, remove_columns=list(typed.columns))
+            self._ds = ds.map(just_text_row, remove_columns=list(ds.columns))
 
-    def _truncate(self, typed: TypedDataset[TextRow]) -> TypedDataset[TextRow]:
-        cumulative = np.cumsum(np.asarray(typed.unwrap()['token_count'], dtype=np.int64))
+    def _truncate(self, ds: TypedDataset[FinewebRow]) -> TypedDataset[FinewebRow]:
+        cumulative = np.cumsum(np.asarray(ds.unwrap()['token_count'], dtype=np.int64))
         cutoff = int(np.searchsorted(cumulative, target_token_count, side='right')) + 1
-        return typed.take(cutoff)
+        return ds.take(cutoff)
 
     def __len__(self) -> int:
         return len(self.ds)

--- a/src/mirror/datasets/fineweb_dataset.py
+++ b/src/mirror/datasets/fineweb_dataset.py
@@ -1,4 +1,4 @@
-from typing import Literal, TypedDict, cast
+from typing import Literal, cast
 
 import numpy as np
 from datasets import DatasetDict
@@ -14,8 +14,7 @@ hf_dataset_name = 'sample-10BT'
 target_token_count = 2_000_000_000
 
 
-class FinewebRow(TypedDict):
-    text: str
+class FinewebRow(TextRow):
     id: str
     dump: str
     url: str

--- a/src/mirror/datasets/fineweb_dataset.py
+++ b/src/mirror/datasets/fineweb_dataset.py
@@ -1,11 +1,13 @@
 from typing import Literal, cast
 
 import numpy as np
-from datasets import Dataset, DatasetDict
+from datasets import DatasetDict
+from typed_datasets import TypedDataset
 
-from mirror.datasets.dataset_util import load_hf_dataset
+from mirror.datasets.dataset_util import load_hf_dataset, to_text_row
 from mirror.datasets.mirror_dataset import MirrorDataset
 from mirror.types import TextRow
+from mirror.util import _ds_cache_path_context
 
 hf_dataset_path = 'HuggingFaceFW/fineweb-edu'
 hf_dataset_name = 'sample-10BT'
@@ -14,7 +16,7 @@ target_token_count = 2_000_000_000
 
 class FinewebDataset(MirrorDataset[TextRow]):
     @property
-    def ds(self) -> Dataset:
+    def ds(self) -> TypedDataset[TextRow]:
         return self._ds
 
     def __init__(
@@ -25,29 +27,21 @@ class FinewebDataset(MirrorDataset[TextRow]):
     ):
         super().__init__()
 
-        self._ds = cast(DatasetDict, load_hf_dataset(
-            hf_dataset_path,
-            hf_dataset_name,
-            self._process,
-        ))[split]
+        raw = cast(DatasetDict, load_hf_dataset(hf_dataset_path, hf_dataset_name))[split]
+        typed: TypedDataset[TextRow] = self._truncate(TypedDataset(raw))
 
         if skip:
-            self._ds = self._ds.select(range(skip, len(self._ds)))
-
+            typed = typed.skip(skip)
         if head:
-            self._ds = self._ds.select(range(head))
+            typed = typed.take(head)
 
-    def _process(self, ds: DatasetDict | Dataset) -> DatasetDict:
-        assert isinstance(ds, DatasetDict)
-        return DatasetDict({split: self._truncate(d) for split, d in ds.items()})
+        with _ds_cache_path_context():
+            self._ds = typed.map(to_text_row, remove_columns=list(typed.columns))
 
-    def _truncate(self, ds: Dataset) -> Dataset:
-        cumulative = np.cumsum(np.asarray(ds['token_count'], dtype=np.int64))
+    def _truncate(self, typed: TypedDataset[TextRow]) -> TypedDataset[TextRow]:
+        cumulative = np.cumsum(np.asarray(typed.unwrap()['token_count'], dtype=np.int64))
         cutoff = int(np.searchsorted(cumulative, target_token_count, side='right')) + 1
-        return ds.select(range(cutoff))
-
-    def to_row_type(self, ds_row: dict) -> TextRow:
-        return TextRow(text=ds_row['text'])
+        return typed.take(cutoff)
 
     def __len__(self) -> int:
         return len(self.ds)

--- a/src/mirror/datasets/imdb_dataset.py
+++ b/src/mirror/datasets/imdb_dataset.py
@@ -3,7 +3,7 @@ from typing import Literal, cast
 from datasets import DatasetDict
 from typed_datasets import TypedDataset
 
-from mirror.datasets.dataset_util import load_hf_dataset, to_text_row
+from mirror.datasets.dataset_util import load_hf_dataset, just_text_row
 from mirror.datasets.mirror_dataset import MirrorDataset
 from mirror.types import TextRow
 from mirror.util import _ds_cache_path_context
@@ -32,15 +32,15 @@ class ImdbDataset(MirrorDataset[TextRow]):
         super().__init__()
 
         raw = cast(DatasetDict, load_hf_dataset(hf_dataset_path))[split]
-        typed: TypedDataset[TextRow] = TypedDataset(raw)
+        ds = TypedDataset[TextRow](raw)
 
         if skip:
-            typed = typed.skip(skip)
+            ds = ds.skip(skip)
         if head:
-            typed = typed.take(head)
+            ds = ds.take(head)
 
         with _ds_cache_path_context():
-            self._ds = typed.map(to_text_row, remove_columns=list(typed.columns))
+            self._ds = ds.map(just_text_row, remove_columns=list(ds.columns))
 
     def __len__(self) -> int:
         return len(self.ds)

--- a/src/mirror/datasets/imdb_dataset.py
+++ b/src/mirror/datasets/imdb_dataset.py
@@ -1,16 +1,19 @@
 from typing import Literal, cast
 
-from datasets import Dataset, DatasetDict
-from mirror.datasets.dataset_util import load_hf_dataset
+from datasets import DatasetDict
+from typed_datasets import TypedDataset
+
+from mirror.datasets.dataset_util import load_hf_dataset, to_text_row
 from mirror.datasets.mirror_dataset import MirrorDataset
 from mirror.types import TextRow
+from mirror.util import _ds_cache_path_context
 
 hf_dataset_path = 'stanfordnlp/imdb'
 
 
 class ImdbDataset(MirrorDataset[TextRow]):
     @property
-    def ds(self) -> Dataset:
+    def ds(self) -> TypedDataset[TextRow]:
         return self._ds
 
     def __init__(
@@ -28,17 +31,19 @@ class ImdbDataset(MirrorDataset[TextRow]):
         """
         super().__init__()
 
-        self._ds = cast(DatasetDict, load_hf_dataset(hf_dataset_path))[split]
-        if skip:
-            self._ds = self._ds.select(range(skip, len(self._ds)))
-        if head:
-            self._ds = self._ds.select(range(head))
+        raw = cast(DatasetDict, load_hf_dataset(hf_dataset_path))[split]
+        typed: TypedDataset[TextRow] = TypedDataset(raw)
 
-    def to_row_type(self, ds_row: dict) -> TextRow:
-        return TextRow(text=ds_row['text'])
+        if skip:
+            typed = typed.skip(skip)
+        if head:
+            typed = typed.take(head)
+
+        with _ds_cache_path_context():
+            self._ds = typed.map(to_text_row, remove_columns=list(typed.columns))
 
     def __len__(self) -> int:
         return len(self.ds)
 
     def item(self, index) -> str:
-       return self.ds['text'][index]
+       return self.ds[index]['text']

--- a/src/mirror/datasets/mirror_dataset.py
+++ b/src/mirror/datasets/mirror_dataset.py
@@ -1,20 +1,19 @@
 from abc import abstractmethod
 from sys import stderr
-from typing import Callable, Sequence, Sized
+from typing import Any, Callable, Sequence, Sized
 from torch.utils.data import Dataset
-from datasets import Dataset as HFDataset
+from typed_datasets import TypedDataset
 from mirror.util import _ds_cache_path_context
 
 
 class MirrorDataset[RawT](Dataset[RawT], Sized):
     @property
     @abstractmethod
-    def ds(self) -> HFDataset:
+    def ds(self) -> TypedDataset[Any]:
         pass
 
-    @abstractmethod
-    def to_row_type(self, ds_row: dict) -> RawT:
-        pass
+    def to_row_type(self, ds_row: RawT) -> RawT:
+        return ds_row
 
     def __getitem__(self, index: int) -> RawT:
         return self.to_row_type(self.ds[index])
@@ -24,11 +23,11 @@ def preprocess_dataset[RawT, ProcessedT](
     dataset: MirrorDataset[RawT],
     preprocessor_function: Callable[[RawT], ProcessedT],
 ) -> Sequence[ProcessedT]:
-    def mappable_preprocessor_function(row: dict) -> dict:
+    def mappable_preprocessor_function(row: RawT) -> dict:
         return {"input_ids": preprocessor_function(dataset.to_row_type(row))}
 
     with _ds_cache_path_context():
-        mapped = dataset.ds.map(mappable_preprocessor_function)
+        mapped = dataset.ds.map(mappable_preprocessor_function).unwrap()
 
     print("Preprocessing complete.", file=stderr)
     mapped.set_format(type="torch", columns=["input_ids"])

--- a/src/mirror/datasets/mirror_dataset.py
+++ b/src/mirror/datasets/mirror_dataset.py
@@ -1,6 +1,6 @@
 from abc import abstractmethod
 from sys import stderr
-from typing import Any, Callable, Mapping, Sequence, Sized
+from typing import Any, Callable, Mapping, Sequence, Sized, cast
 from torch.utils.data import Dataset
 from typed_datasets import TypedDataset
 from mirror.util import _ds_cache_path_context
@@ -12,8 +12,8 @@ class MirrorDataset[RawT: Mapping[str, Any]](Dataset[RawT], Sized):
     def ds(self) -> TypedDataset[RawT]:
         pass
 
-    def to_row_type(self, ds_row: RawT) -> RawT:
-        return ds_row
+    def to_row_type(self, ds_row: Mapping[str, Any]) -> RawT:
+        return cast(RawT, ds_row)
 
     def __getitem__(self, index: int) -> RawT:
         return self.to_row_type(self.ds[index])
@@ -23,11 +23,11 @@ def preprocess_dataset[RawT: Mapping[str, Any], ProcessedT](
     dataset: MirrorDataset[RawT],
     preprocessor_function: Callable[[RawT], ProcessedT],
 ) -> Sequence[ProcessedT]:
-    def mappable_preprocessor_function(row: RawT) -> dict:
+    def mappable_preprocessor_function(row: dict) -> dict:
         return {"input_ids": preprocessor_function(dataset.to_row_type(row))}
 
     with _ds_cache_path_context():
-        mapped = dataset.ds.map(mappable_preprocessor_function).unwrap()
+        mapped = dataset.ds.unwrap().map(mappable_preprocessor_function)
 
     print("Preprocessing complete.", file=stderr)
     mapped.set_format(type="torch", columns=["input_ids"])

--- a/src/mirror/datasets/mirror_dataset.py
+++ b/src/mirror/datasets/mirror_dataset.py
@@ -1,15 +1,15 @@
 from abc import abstractmethod
 from sys import stderr
-from typing import Any, Callable, Sequence, Sized
+from typing import Any, Callable, Mapping, Sequence, Sized
 from torch.utils.data import Dataset
 from typed_datasets import TypedDataset
 from mirror.util import _ds_cache_path_context
 
 
-class MirrorDataset[RawT](Dataset[RawT], Sized):
+class MirrorDataset[RawT: Mapping[str, Any]](Dataset[RawT], Sized):
     @property
     @abstractmethod
-    def ds(self) -> TypedDataset[Any]:
+    def ds(self) -> TypedDataset[RawT]:
         pass
 
     def to_row_type(self, ds_row: RawT) -> RawT:
@@ -19,7 +19,7 @@ class MirrorDataset[RawT](Dataset[RawT], Sized):
         return self.to_row_type(self.ds[index])
 
 
-def preprocess_dataset[RawT, ProcessedT](
+def preprocess_dataset[RawT: Mapping[str, Any], ProcessedT](
     dataset: MirrorDataset[RawT],
     preprocessor_function: Callable[[RawT], ProcessedT],
 ) -> Sequence[ProcessedT]:

--- a/src/mirror/datasets/mixed_dataset.py
+++ b/src/mirror/datasets/mixed_dataset.py
@@ -1,15 +1,14 @@
 from __future__ import annotations
 
 import math
-from typing import Sequence, cast
+from typing import Any, Mapping, Sequence
 
-from datasets import Dataset as HFDataset
-from datasets import concatenate_datasets
+from typed_datasets import TypedDataset, concatenate
 
 from mirror.datasets.mirror_dataset import MirrorDataset
 
 
-class MixedDataset[RawT](MirrorDataset[RawT]):
+class MixedDataset[RawT: Mapping[str, Any]](MirrorDataset[RawT]):
     def __init__(
         self,
         weighted_datasets: Sequence[tuple[MirrorDataset[RawT], float]],
@@ -20,7 +19,7 @@ class MixedDataset[RawT](MirrorDataset[RawT]):
         normalized_weights = [w / total_weight for _, w in weighted_datasets]
         scale = max(len(ds) / w for (ds, _), w in zip(weighted_datasets, normalized_weights))
 
-        selected: list[HFDataset] = []
+        selected: list[TypedDataset[RawT]] = []
 
         for (ds, _), w in zip(weighted_datasets, normalized_weights):
             target_count = math.ceil(scale * w)
@@ -28,14 +27,11 @@ class MixedDataset[RawT](MirrorDataset[RawT]):
             upsampled = [i % ds_len for i in range(target_count)]
             selected.append(ds.ds.select(upsampled))
 
-        self._ds = concatenate_datasets(selected)
+        self._ds = concatenate(selected)
 
     @property
-    def ds(self) -> HFDataset:
+    def ds(self) -> TypedDataset[RawT]:
         return self._ds
-
-    def __getitem__(self, index: int) -> RawT:
-        return cast(RawT, self._ds[index])
 
     def __len__(self) -> int:
         return len(self.ds)

--- a/src/mirror/datasets/on_demand_preprocessed_dataset.py
+++ b/src/mirror/datasets/on_demand_preprocessed_dataset.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
-from typing import Callable
+from typing import Any, Callable, Mapping
 from torch.utils.data import Dataset
 
 from mirror.datasets.mirror_dataset import MirrorDataset
 
-class OnDemandPreprocessedDataset[RawT, ProcessedT](Dataset[ProcessedT]):
+class OnDemandPreprocessedDataset[RawT: Mapping[str, Any], ProcessedT](Dataset[ProcessedT]):
     def __init__(
             self, 
             raw_dataset: MirrorDataset[RawT], 

--- a/src/mirror/datasets/txt_dataset.py
+++ b/src/mirror/datasets/txt_dataset.py
@@ -2,7 +2,7 @@ from pathlib import Path
 from typing import cast
 
 from datasets import Dataset, load_dataset
-from typed_datasets import TypedDataset, load_typed
+from typed_datasets import TypedDataset
 
 from mirror.datasets.mirror_dataset import MirrorDataset
 from mirror.types import TextRow
@@ -22,21 +22,18 @@ class TxtDataset(MirrorDataset[TextRow]):
         """
         Args:
             file_path: path to a .txt file where each line is one example.
-            head: how many non-empty examples to include. None includes the whole file.
+            head: how many examples to include. None includes the whole file.
         """
         super().__init__()
 
-        if head is not None:
-            stream = load_typed(
-                "text", row_type=TextRow, split="train",
-                streaming=True, data_files=str(file_path),
-            )
-            rows = list(stream.filter(lambda row: len(row['text']) > 0).take(head))
-            self._ds = TypedDataset.from_list(rows)
-        else:
-            raw = cast(Dataset, load_dataset("text", data_files=str(file_path), split="train"))
-            with _ds_cache_path_context():
-                self._ds = TypedDataset(raw).filter(lambda row: len(row['text']) > 0)
+        raw = cast(Dataset, load_dataset("text", data_files=str(file_path), split="train"))
+        ds = TypedDataset[TextRow](raw)
+
+        with _ds_cache_path_context():
+            ds = ds.filter(lambda row: len(row['text']) > 0)
+            if head:
+                ds = ds.take(head)
+            self._ds = ds
 
     def __len__(self) -> int:
         return len(self.ds)

--- a/src/mirror/datasets/txt_dataset.py
+++ b/src/mirror/datasets/txt_dataset.py
@@ -2,13 +2,16 @@ from pathlib import Path
 from typing import cast
 
 from datasets import Dataset, load_dataset
+from typed_datasets import TypedDataset, load_typed
+
 from mirror.datasets.mirror_dataset import MirrorDataset
 from mirror.types import TextRow
+from mirror.util import _ds_cache_path_context
 
 
 class TxtDataset(MirrorDataset[TextRow]):
     @property
-    def ds(self) -> Dataset:
+    def ds(self) -> TypedDataset[TextRow]:
         return self._ds
 
     def __init__(
@@ -19,17 +22,21 @@ class TxtDataset(MirrorDataset[TextRow]):
         """
         Args:
             file_path: path to a .txt file where each line is one example.
-            head: how many examples to include. None includes the whole split.
+            head: how many non-empty examples to include. None includes the whole file.
         """
         super().__init__()
 
-        self._ds = cast(Dataset, load_dataset("text", data_files=str(file_path), split="train"))
-        self._ds = self._ds.filter(lambda row: len(row["text"]) > 0)
-        if head:
-            self._ds = self._ds.select(range(head))
-
-    def to_row_type(self, ds_row: dict) -> TextRow:
-        return TextRow(text=ds_row['text'])
+        if head is not None:
+            stream = load_typed(
+                "text", row_type=TextRow, split="train",
+                streaming=True, data_files=str(file_path),
+            )
+            rows = list(stream.filter(lambda row: len(row['text']) > 0).take(head))
+            self._ds = TypedDataset.from_list(rows)
+        else:
+            raw = cast(Dataset, load_dataset("text", data_files=str(file_path), split="train"))
+            with _ds_cache_path_context():
+                self._ds = TypedDataset(raw).filter(lambda row: len(row['text']) > 0)
 
     def __len__(self) -> int:
         return len(self.ds)

--- a/src/mirror/datasets/wikitext_dataset.py
+++ b/src/mirror/datasets/wikitext_dataset.py
@@ -3,7 +3,7 @@ from typing import Literal, cast
 from datasets import DatasetDict
 from typed_datasets import TypedDataset
 
-from mirror.datasets.dataset_util import load_hf_dataset, to_text_row
+from mirror.datasets.dataset_util import load_hf_dataset, just_text_row
 from mirror.datasets.mirror_dataset import MirrorDataset
 from mirror.types import TextRow
 from mirror.util import _ds_cache_path_context
@@ -32,16 +32,15 @@ class WikitextDataset(MirrorDataset[TextRow]):
         super().__init__()
 
         raw = cast(DatasetDict, load_hf_dataset(hf_dataset_path, hf_dataset_name))[split]
-        typed: TypedDataset[TextRow] = TypedDataset(raw)
-
-        if skip:
-            typed = typed.skip(skip)
-        if head:
-            typed = typed.take(head)
+        ds = TypedDataset[TextRow](raw)
 
         with _ds_cache_path_context():
-            typed = typed.filter(lambda row: len(row['text']) > 0)
-            self._ds = typed.map(to_text_row, remove_columns=list(typed.columns))
+            ds = ds.filter(lambda row: len(row['text']) > 0)
+            if skip:
+                ds = ds.skip(skip)
+            if head:
+                ds = ds.take(head)
+            self._ds = ds.map(just_text_row, remove_columns=list(ds.columns))
 
     def __len__(self) -> int:
         return len(self.ds)

--- a/src/mirror/datasets/wikitext_dataset.py
+++ b/src/mirror/datasets/wikitext_dataset.py
@@ -1,10 +1,12 @@
 from typing import Literal, cast
 
-from datasets import Dataset, DatasetDict
+from datasets import DatasetDict
+from typed_datasets import TypedDataset
 
-from mirror.datasets.dataset_util import load_hf_dataset
+from mirror.datasets.dataset_util import load_hf_dataset, to_text_row
 from mirror.datasets.mirror_dataset import MirrorDataset
 from mirror.types import TextRow
+from mirror.util import _ds_cache_path_context
 
 hf_dataset_path = 'Salesforce/wikitext'
 hf_dataset_name = 'wikitext-2-raw-v1'
@@ -12,7 +14,7 @@ hf_dataset_name = 'wikitext-2-raw-v1'
 
 class WikitextDataset(MirrorDataset[TextRow]):
     @property
-    def ds(self) -> Dataset:
+    def ds(self) -> TypedDataset[TextRow]:
         return self._ds
 
     def __init__(
@@ -29,23 +31,17 @@ class WikitextDataset(MirrorDataset[TextRow]):
         """
         super().__init__()
 
-        self._ds = cast(DatasetDict, load_hf_dataset(
-            hf_dataset_path,
-            hf_dataset_name,
-            self._process,
-        ))[split]
+        raw = cast(DatasetDict, load_hf_dataset(hf_dataset_path, hf_dataset_name))[split]
+        typed: TypedDataset[TextRow] = TypedDataset(raw)
 
         if skip:
-            self._ds = self._ds.select(range(skip, len(self._ds)))
-
+            typed = typed.skip(skip)
         if head:
-            self._ds = self._ds.select(range(head))
+            typed = typed.take(head)
 
-    def _process(self, ds: DatasetDict | Dataset) -> DatasetDict | Dataset:
-        return ds.filter(lambda row: len(row['text']) > 0)
-
-    def to_row_type(self, ds_row: dict) -> TextRow:
-        return TextRow(text=ds_row['text'])
+        with _ds_cache_path_context():
+            typed = typed.filter(lambda row: len(row['text']) > 0)
+            self._ds = typed.map(to_text_row, remove_columns=list(typed.columns))
 
     def __len__(self) -> int:
         return len(self.ds)

--- a/src/mirror/trainer.py
+++ b/src/mirror/trainer.py
@@ -2,7 +2,7 @@ import datetime
 import os
 import warnings
 from itertools import islice
-from typing import Any, List, cast
+from typing import Any, List, Mapping, cast
 
 import torch
 from lightning import Fabric
@@ -30,7 +30,7 @@ from mirror.preprocessors.mirror_preprocessor import MirrorPreprocessor
 from mirror.requeue_monitor import RequeueMonitor
 from mirror.dict_types import StateDict
 
-class Trainer[RawT, ProcessedT, BatchT, ModelOutputT]:
+class Trainer[RawT: Mapping[str, Any], ProcessedT, BatchT, ModelOutputT]:
     def __init__(
             self,
             strategy: Strategy | None = None,
@@ -256,7 +256,7 @@ class Trainer[RawT, ProcessedT, BatchT, ModelOutputT]:
     def _make_fabric(self, strategy: Strategy, accelerator: str) -> Fabric:
         return make_fabric(strategy, accelerator, devices=self.devices, num_nodes=self.num_nodes, callbacks=self.callbacks)
 
-def separate_singletons[RawT, ProcessedT, BatchT, ModelOutputT](
+def separate_singletons[RawT: Mapping[str, Any], ProcessedT, BatchT, ModelOutputT](
         callbacks: List[Callback[RawT, ProcessedT, BatchT, ModelOutputT]]
 ) -> tuple[
         List[Callback[RawT, ProcessedT, BatchT, ModelOutputT]],
@@ -267,7 +267,7 @@ def separate_singletons[RawT, ProcessedT, BatchT, ModelOutputT](
     return singletons, non_singletons
 
 
-def make_dataloader[RawT, ProcessedT, BatchT](
+def make_dataloader[RawT: Mapping[str, Any], ProcessedT, BatchT](
         dataset: MirrorDataset[RawT],
         preprocessor: MirrorPreprocessor[RawT, ProcessedT, BatchT],
         batch_size: int,

--- a/src/mirror/trainer_constructor.py
+++ b/src/mirror/trainer_constructor.py
@@ -1,3 +1,4 @@
+from typing import Any, Mapping
 from lightning.fabric.strategies.strategy import Strategy
 from lightning.fabric.strategies.fsdp import FSDPStrategy
 from mirror.callbacks.callback import Callback
@@ -17,5 +18,5 @@ class TrainerConstructor:
         self.num_nodes = num_nodes
         self.callbacks = callbacks
 
-    def construct_trainer[RawT, ProcessedT, BatchT, ModelOutputT](self) -> Trainer[RawT, ProcessedT, BatchT, ModelOutputT]:
+    def construct_trainer[RawT: Mapping[str, Any], ProcessedT, BatchT, ModelOutputT](self) -> Trainer[RawT, ProcessedT, BatchT, ModelOutputT]:
         return Trainer(self.strategy, self.devices, self.num_nodes, self.callbacks)


### PR DESCRIPTION
Closes #345 

## Caching note

The init-time `map`/`filter` are cached by HuggingFace and do **not** re-run on subsequent constructions — verified that two separate processes reuse the cached result (identical fingerprint, no recompute, no random-hash warning). `.select` (skip/take) writes no cache files, so reductions run outside the cache-path context; only `filter`/`map` run inside it. To keep caching effective, transform functions are kept free of run-varying captured state (module-level `to_text_row`, simple lambdas).

## Testing

Ran with the project env (`./.env/bin/python`):

- **Construction / typing**: `WikitextDataset(head=10)`, `ImdbDataset(head=10)`, `MixedDataset` of two → all construct; `ds` is a `TypedDataset`; rows stripped to exactly `{text}` (imdb's `label` dropped); `to_row_type` confirmed identity.
- **Caching**: same dataset built in two separate processes → second shows no `Map:`/`Filter:` recompute.
- **`_truncate`**: synthetic token-count dataset → keeps the expected cutoff rows (no 10BT download needed).
- **Txt streaming**: 1M-line file with blanks, `head=3` → returns exactly the first 3 non-empty rows near-instantly (no full scan); no-`head` path filters the whole file correctly.
- **`make_dataloader`**: both `do_preprocess=True` (`preprocess_dataset`) and `False` (`OnDemandPreprocessedDataset`) paths produce valid batches.
- Ran full training run with `fit`, both with and without do_preprocess=True

## Flags for reviewers

- **`preprocess_dataset` caching is unchanged / pre-existing.** The `do_preprocess=True` path emits HF's "couldn't be hashed, random hash used" warning because its local closure captures the dataset/preprocessor. This closure pattern is identical on `main` — out of scope for #345. (The init-time dataset processing that this ticket targets *does* cache.)
- **Type-bound scope.** Bounding `MirrorDataset[RawT]` to `Mapping[str, Any]` cascaded through the callback/trainer generics (~12 files). `RequeueMonitor`/`StateDict`/`MirrorModel`/`MirrorPreprocessor`/`MirrorMetric` were intentionally left unbounded since they don't feed `RawT` into a bounded type.
