### PR TITLE
Changes to get the fine tuning done. 1. trainer - Throwing the global…

### DIFF
--- a/src/mirror/callbacks/callback.py
+++ b/src/mirror/callbacks/callback.py
@@ -78,6 +78,21 @@ class Callback[RawT: Mapping[str, Any], FormattedT: Mapping[str, Any], BatchT, M
     ):
         pass
 
+    def on_epoch_end(
+            self,
+            *,
+            fabric: Fabric,
+            model: MirrorModel[RawT, FormattedT, BatchT, ModelOutputT],
+            optimizer: Optimizer,
+            training_run_id: str,
+            epoch: int,
+            epochs: int,
+            n_batches: int,
+            global_step: int,
+            optimization_step: int,
+    ):
+        pass
+
     def on_validation_epoch_end(
             self,
             *,

--- a/src/mirror/callbacks/checkpoint_callback.py
+++ b/src/mirror/callbacks/checkpoint_callback.py
@@ -10,9 +10,10 @@ from mirror.dict_types import StateDict
 class CheckpointCallback[RawT: Mapping[str, Any], FormattedT: Mapping[str, Any], BatchT, ModelOutputT](
        Callback[RawT, FormattedT, BatchT, ModelOutputT]
 ):
-    def __init__(self, every_n_training_steps: int | None = None) -> None:
+    def __init__(self, every_n_training_steps: int | None = None, every_n_epochs: int | None = None) -> None:
         super().__init__(is_singleton=True)
         self.every_n_training_steps = every_n_training_steps
+        self.every_n_epochs = every_n_epochs
 
     def on_fit_start(
             self,
@@ -72,6 +73,28 @@ class CheckpointCallback[RawT: Mapping[str, Any], FormattedT: Mapping[str, Any],
                 CheckpointIdentifier(training_run_id, f"{optimization_step:0{n_print_digits}d}"),
                 global_step,
                 optimization_step,
+            )
+
+    def on_epoch_end(
+            self,
+            *,
+            fabric: Fabric,
+            model: MirrorModel[RawT, FormattedT, BatchT, ModelOutputT],
+            optimizer: Optimizer,
+            training_run_id: str,
+            epoch: int,
+            epochs: int,
+            n_batches: int,
+            global_step: int,
+            optimization_step: int,
+            **kwargs,
+    ):
+        if self.every_n_epochs and (epoch + 1) % self.every_n_epochs == 0:
+            n_print_digits = len(str(epochs)) + 1
+            self._save_checkpoint(
+                fabric, model, optimizer,
+                CheckpointIdentifier(training_run_id, f"epoch_{epoch + 1:0{n_print_digits}d}"),
+                global_step, optimization_step,
             )
 
     def _save_checkpoint(

--- a/src/mirror/datasets/csv_dataset.py
+++ b/src/mirror/datasets/csv_dataset.py
@@ -72,6 +72,8 @@ class CsvInstructDataset(MirrorDataset[PromptResponseRow]):
         prompt_template: str,
         response_template: str,
         head: int | None = None,
+        start_fraction: float = 0.0,
+        end_fraction: float = 1.0,
     ) -> None:
         super().__init__()
         ptmpl = prompt_template
@@ -84,7 +86,8 @@ class CsvInstructDataset(MirrorDataset[PromptResponseRow]):
                 response=rtmpl.format(**cleaned),
             )
 
-        raw = cast(Dataset, load_dataset("csv", data_files=str(file_path), split="train"))
+        split = f"train[{round(start_fraction * 100)}%:{round(end_fraction * 100)}%]"
+        raw = cast(Dataset, load_dataset("csv", data_files=str(file_path), split=split))
         with _ds_cache_path_context():
             ds = TypedDataset[PromptResponseRow](raw.map(render, remove_columns=raw.column_names))
             ds = ds.filter(lambda row: len(row['response']) > 0)

--- a/src/mirror/trainer.py
+++ b/src/mirror/trainer.py
@@ -133,13 +133,11 @@ class Trainer[RawT: Mapping[str, Any], FormattedT: Mapping[str, Any], BatchT, Mo
             # models and optimizers are treated specially: they are populated via their load_state_dict
             # methods internally to fabric.load. Anything else in the state dict is just set in place.
 
-            self.fabric.load(checkpoint.path, cast(dict[str, torch.nn.Module | torch.optim.Optimizer | Any], state))
+            self.fabric.load(checkpoint.path, cast(dict[str, torch.nn.Module | torch.optim.Optimizer | Any], state), strict=False)
 
             if state['global_step'] is None:
-                raise RuntimeError(
-                    "checkpoint_global_step cannot be None. "
-                    f"checkpoint '{checkpoint.checkpoint_name}' gave an invalid global step value."
-                    )
+                state['global_step'] = 0
+                state['optimization_step'] = 0
 
         if self.config['environment'] == RuntimeEnvironment.SLURM_COMPUTE:
             self.requeue_monitor = RequeueMonitor[RawT, FormattedT, BatchT, ModelOutputT](self.fabric)
@@ -220,6 +218,10 @@ class Trainer[RawT: Mapping[str, Any], FormattedT: Mapping[str, Any], BatchT, Mo
                             state=state,
                             training_run_id=training_run_id,
                         )
+
+                self.fabric.call('on_epoch_end', fabric=self.fabric, model=model, optimizer=optimizer,
+                                 training_run_id=training_run_id, epoch=epoch_idx, epochs=epochs,
+                                 n_batches=n_batches, global_step=global_step, optimization_step=optimization_step)
 
                 if val_dataloader is not None and (epoch_idx + 1) % val_check_interval == 0:
                     val_loss = self._eval_loop(model, val_dataloader)


### PR DESCRIPTION
Changes to get the fine tuning done:

1. trainer - Throwing the `global_step == None` error meant there coudl be no fine tuning the completely trained models. Perhaps it would be better if we just added a parameter to pass into Trainer that dodges this error and sets `global_step = 0` so training works that way we don't avoid wanted errors. 

2. Checkpoint callback - for convenience I added per-epoch functionality to the checkpoints. 

3. csv_dataset - added fractional splitting up of datasets.


Tested by actually running the fine tuning on the models.