### PR TITLE
393 try instruct tuning to very easy task

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,6 @@
 {
   "python.defaultInterpreterPath": "${workspaceFolder}/.env/bin/python",
-  "python.terminal.activateEnvironment": false
+  "python.terminal.activateEnvironment": false,
+  "python-envs.defaultEnvManager": "ms-python.python:conda",
+  "python-envs.defaultPackageManager": "ms-python.python:conda"
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,4 @@
 {
   "python.defaultInterpreterPath": "${workspaceFolder}/.env/bin/python",
-  "python.terminal.activateEnvironment": false,
-  "python-envs.defaultEnvManager": "ms-python.python:conda",
-  "python-envs.defaultPackageManager": "ms-python.python:conda"
+  "python.terminal.activateEnvironment": false
 }

--- a/src/mirror/callbacks/checkpoint_callback.py
+++ b/src/mirror/callbacks/checkpoint_callback.py
@@ -10,9 +10,14 @@ from mirror.dict_types import StateDict
 class CheckpointCallback[RawT: Mapping[str, Any], FormattedT: Mapping[str, Any], BatchT](
        Callback[RawT, FormattedT, BatchT]
 ):
-    def __init__(self, every_n_training_steps: int | None = None) -> None:
+    def __init__(
+            self,
+            every_n_training_steps: int | None = None,
+            every_n_epochs: int | None = None,
+    ) -> None:
         super().__init__(is_singleton=True)
         self.every_n_training_steps = every_n_training_steps
+        self.every_n_epochs = every_n_epochs
 
     def on_fit_start(
             self,
@@ -73,6 +78,35 @@ class CheckpointCallback[RawT: Mapping[str, Any], FormattedT: Mapping[str, Any],
                 global_step,
                 optimization_step,
             )
+
+    def on_train_batch_end(
+            self,
+            *,
+            fabric: Fabric,
+            model: TrainableModel[RawT, FormattedT, BatchT],
+            optimizer: Optimizer,
+            training_run_id: str,
+            epochs: int,
+            n_batches: int,
+            batch_idx: int,
+            global_step: int,
+            optimization_step: int,
+            **kwargs,
+    ):
+        if self.every_n_epochs is None or batch_idx != n_batches - 1:
+            return
+        completed_epoch = global_step // n_batches
+        if completed_epoch % self.every_n_epochs != 0:
+            return
+        n_print_digits = len(str(epochs)) + 1
+        self._save_checkpoint(
+            fabric,
+            model,
+            optimizer,
+            CheckpointIdentifier(training_run_id, f"epoch_{completed_epoch:0{n_print_digits}d}"),
+            global_step,
+            optimization_step,
+        )
 
     def _save_checkpoint(
             self,

--- a/src/mirror/datasets/__init__.py
+++ b/src/mirror/datasets/__init__.py
@@ -1,4 +1,5 @@
 from mirror.datasets.csv_dataset import CsvDataset, CsvInstructDataset
+from mirror.datasets.echo_dataset import EchoDataset
 from mirror.datasets.fineweb_dataset import FinewebDataset
 from mirror.datasets.imdb_dataset import ImdbDataset
 from mirror.datasets.mixed_dataset import MixedDataset

--- a/src/mirror/datasets/csv_dataset.py
+++ b/src/mirror/datasets/csv_dataset.py
@@ -72,6 +72,8 @@ class CsvInstructDataset(MirrorDataset[PromptResponseRow]):
         prompt_template: str,
         response_template: str,
         head: int | None = None,
+        start_fraction: float = 0.0,
+        end_fraction: float = 1.0,
     ) -> None:
         super().__init__()
         ptmpl = prompt_template
@@ -84,7 +86,8 @@ class CsvInstructDataset(MirrorDataset[PromptResponseRow]):
                 response=rtmpl.format(**cleaned),
             )
 
-        raw = cast(Dataset, load_dataset("csv", data_files=str(file_path), split="train"))
+        split = f"train[{round(start_fraction * 100)}%:{round(end_fraction * 100)}%]"
+        raw = cast(Dataset, load_dataset("csv", data_files=str(file_path), split=split))
         with _ds_cache_path_context():
             ds = TypedDataset[PromptResponseRow](raw.map(render, remove_columns=raw.column_names))
             ds = ds.filter(lambda row: len(row['response']) > 0)

--- a/src/mirror/datasets/echo_dataset.py
+++ b/src/mirror/datasets/echo_dataset.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+from typing import cast
+
+from datasets import Dataset, load_dataset
+from typed_datasets import TypedDataset
+
+from mirror.datasets.mirror_dataset import MirrorDataset
+from mirror.types import PromptResponseRow
+from mirror.util import _ds_cache_path_context
+
+
+class EchoDataset(MirrorDataset[PromptResponseRow]):
+    """
+    Sanity-check dataset for instruction fine-tuning. Reads a single column
+    from a CSV and sets response = prompt, so the model must learn to echo
+    its input. If instruction fine-tuning can't solve this task, something
+    is broken in the pipeline.
+
+        EchoDataset(file_path)                        # uses "query" column
+        EchoDataset(file_path, prompt_column="text")  # custom column name
+    """
+
+    @property
+    def ds(self) -> TypedDataset[PromptResponseRow]:
+        return self._ds
+
+    def __init__(
+        self,
+        file_path: str | Path,
+        prompt_column: str = "query",
+        skip: int | None = None,
+        head: int | None = None,
+    ) -> None:
+        super().__init__()
+        col = prompt_column
+
+        def render(row: dict) -> PromptResponseRow:
+            text = "" if row[col] is None else str(row[col])
+            return PromptResponseRow(prompt=text, response=text)
+
+        raw = cast(Dataset, load_dataset("csv", data_files=str(file_path), split="train"))
+        if skip:
+            raw = raw.select(range(skip, len(raw)))
+        with _ds_cache_path_context():
+            ds = TypedDataset[PromptResponseRow](raw.map(render, remove_columns=raw.column_names))
+            ds = ds.filter(lambda row: len(row["prompt"]) > 0)
+            if head:
+                ds = ds.take(head)
+        self._ds = ds
+
+    def __len__(self) -> int:
+        return len(self.ds)

--- a/src/mirror/formatters/bpe_formatter.py
+++ b/src/mirror/formatters/bpe_formatter.py
@@ -15,7 +15,7 @@ from mirror.types import LabeledTokens, StandardBatch, TextRow
 
 from mirror.util import _ds_cache_path_context, mirror_data_path
 
-_SPECIAL_TOKENS = ["<unk>", "<s>", "</s>", "<pad>", "<|user|>", "<|assistant|>"]
+_SPECIAL_TOKENS = ["<unk>", "<s>", "</s>", "<pad>"] # "<|user|>", "<|assistant|>"
 
 _CHAT_TEMPLATE = (
     "<s>"
@@ -63,7 +63,7 @@ class BPEFormatter(
             eos_token="</s>",
             unk_token="<unk>",
             pad_token="<pad>",
-            additional_special_tokens=["<|user|>", "<|assistant|>"],
+            # additional_special_tokens=["<|user|>", "<|assistant|>"],
         )
         self._tokenizer.chat_template = _CHAT_TEMPLATE
 

--- a/src/mirror/trainer.py
+++ b/src/mirror/trainer.py
@@ -143,7 +143,7 @@ class Trainer[RawT: Mapping[str, Any], FormattedT: Mapping[str, Any], BatchT]:
                 else:
                     raise RuntimeError(
                         "checkpoint_global_step cannot be None. "
-                        f"checkpoint '{checkpoint.checkpoint_name}' gave an invalid global step value."
+                        f"checkpoint '{checkpoint.checkpoint_name}' gave an invalid global step value. Pass in `just_checkpoint_weights: True` to byoass this error."
                     )
 
         if self.config['environment'] == RuntimeEnvironment.SLURM_COMPUTE:

--- a/src/mirror/trainer.py
+++ b/src/mirror/trainer.py
@@ -38,6 +38,7 @@ class Trainer[RawT: Mapping[str, Any], FormattedT: Mapping[str, Any], BatchT]:
             num_nodes: int = 1,
             callbacks: List[Callback[RawT, FormattedT, BatchT]] = [],
             precision: _PRECISION_INPUT | None = None,
+            just_checkpoint_weights: bool = False,
     ) -> None:
         self.precision: _PRECISION_INPUT | None = precision
         if strategy is None:
@@ -60,6 +61,7 @@ class Trainer[RawT: Mapping[str, Any], FormattedT: Mapping[str, Any], BatchT]:
         if os.getenv("MIRROR_PRINT_STEP_LOSS", "").lower() == "true":
             default_callbacks.append(PrintStepCallback())
 
+        self.just_checkpoint_weights = just_checkpoint_weights
         self.requeue_monitor: RequeueMonitor[RawT, FormattedT, BatchT] | None = None
 
         default_singleton_cbs, default_non_singleton_cbs = separate_singletons(default_callbacks)
@@ -133,12 +135,15 @@ class Trainer[RawT: Mapping[str, Any], FormattedT: Mapping[str, Any], BatchT]:
             # models and optimizers are treated specially: they are populated via their load_state_dict
             # methods internally to fabric.load. Anything else in the state dict is just set in place.
 
-            self.fabric.load(checkpoint.path, cast(dict[str, torch.nn.Module | torch.optim.Optimizer | Any], state))
+            self.fabric.load(checkpoint.path, cast(dict[str, torch.nn.Module | torch.optim.Optimizer | Any], state), strict=False)
 
             if state['global_step'] is None:
-                raise RuntimeError(
-                    "checkpoint_global_step cannot be None. "
-                    f"checkpoint '{checkpoint.checkpoint_name}' gave an invalid global step value."
+                if self.just_checkpoint_weights:
+                    state['global_step'] = 0
+                else:
+                    raise RuntimeError(
+                        "checkpoint_global_step cannot be None. "
+                        f"checkpoint '{checkpoint.checkpoint_name}' gave an invalid global step value."
                     )
 
         if self.config['environment'] == RuntimeEnvironment.SLURM_COMPUTE:

--- a/src/mirror/trainer_constructor.py
+++ b/src/mirror/trainer_constructor.py
@@ -14,12 +14,14 @@ class TrainerConstructor:
             num_nodes: int = 1,
             callbacks: list[Callback] = [],
             precision: _PRECISION_INPUT | None = None,
+            just_checkpoint_weights: bool = False,
     ) -> None:
         self.strategy = strategy
         self.devices = devices
         self.num_nodes = num_nodes
         self.callbacks = callbacks
         self.precision: _PRECISION_INPUT | None = precision
+        self.just_checkpoint_weights = just_checkpoint_weights
 
     def construct_trainer[RawT: Mapping[str, Any], FormattedT: Mapping[str, Any], BatchT](self) -> Trainer[RawT, FormattedT, BatchT]:
-        return Trainer(self.strategy, self.devices, self.num_nodes, self.callbacks, self.precision)
+        return Trainer(self.strategy, self.devices, self.num_nodes, self.callbacks, self.precision, self.just_checkpoint_weights)


### PR DESCRIPTION
Tested by training several fine-tuned models on this.

Notes:
passing in strict=False into the thing in trainer was necessary for the checkpoints to work. I don't fully understand why.
yeah I think that's it for notes.

**UPDATED PR:**
This branch now has changes pertinent to several other branches. 

1. `every_n_epochs` for checkpoint callback.
2. Corrected BPEFormatter for our 100M parameter training runs. (The changes made for this were designed to be temporary. Ideally as soon as we are done with the 100M parameter training—I guess we might actually be done with that...—we should revert the changes in the BPEFormatter.) Closes #397.
3. Fractional splitting of the CSVDataset was implemented.
4. Echo Dataset was created to test instruct tuning. Closes #393.
5. A `just_checkpoint_weights` parameter was created for trainer so that it is now possible to begin training runs using an `end.ckpt`. (Previously we designed infrastructure that prohibited this as it didn't seem to make sense to continue a training run that was already complete, but this change demonstrates our understanding of the fact that the checkpoints are not just used to continue training runs, but also to store and deliver model weights.) Closes #321.

All of the above was tested by running the actual fine-tuning training runs.