### PR TITLE
40 hyperparam grid search

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,31 @@
       device: cpu
       ```
 
-5. Weights & Biases tracking is enabled by default through `Trainer`.
+5. Hyperparameter grid search: add a top-level `grid` section mapping config
+   options (dotted paths) to a list of values. At submission time a separate
+   SLURM job is launched for every combination (the Cartesian product) of the
+   listed values, each overriding the base config.
+   ```
+   grid:
+     epochs: [1, 2]
+     batch_size: [4, 8]
+     model.init_args.lr: [1e-3, 1e-4]
+     slurm.gpus_per_node: [p100:1, a100:1]
+   ```
+   The example above launches 2 × 2 × 2 × 2 = 16 jobs. A single value (e.g.
+   `epochs: [2]`) is allowed and simply contributes one point to the search.
+
+   A value may be a whole `class_path`/`init_args` block (or `null`), so you can
+   sweep over entire component definitions, e.g. comparing trainers or models:
+   ```
+   grid:
+     trainer:
+       - class_path: TrainerConstructor
+         init_args:
+           callbacks: [{class_path: WandbCallback}]
+       - null   # default trainer
+   ```
+
+6. Weights & Biases tracking is enabled by default through `Trainer`.
     - On SLURM compute nodes it defaults to offline mode and writes runs to `~/nobackup/autodelete/mirror_data/wandb`.
     - Sync cached runs later from a login node with `wandb sync ~/nobackup/autodelete/mirror_data/wandb/offline-run-*`.

--- a/docs/mirror onboarding/config-example.md
+++ b/docs/mirror onboarding/config-example.md
@@ -102,5 +102,9 @@ slurm:
 epochs: 1         # Total training epochs
 batch_size: 1     # Examples per gradient-update step
 device: cpu       # Compute device: "cpu" | "cuda" (auto-detected on SLURM compute nodes)
+
+# grid:                              # Optional: launch one run per combination of values
+#   epochs: [1, 2]                   # Each key is an option's dotted config path
+#   model.init_args.lr: [1e-3, 1e-4] # The example below launches 2 x 2 = 4 jobs
 ```
 

--- a/docs/mirror onboarding/mirror onboarding.md
+++ b/docs/mirror onboarding/mirror onboarding.md
@@ -427,6 +427,28 @@ Run the following command:
 
 Replace `fit` with `format` if you are just trying to do a formatting run. It's smart to make a separate config file for formatting, which won't need parameters like `model`, `val_data`, `test_data`, etc. That way, instead of constantly editing your main config file, you can just pass in your formatting config file for formatting runs.
 
+#### Running a hyperparameter grid search
+
+To try multiple values for one or more options, add a top-level `grid` section mapping each option (by its dotted config path) to a list of values. When you submit, a separate training run is launched for every combination of those values (the Cartesian product):
+
+```yaml
+grid:
+  epochs: [1, 2]                       # Top-level option
+  model.init_args.lr: [1e-3, 1e-4]     # Nested option, addressed by dotted path
+  slurm.gpus_per_node: [p100:1, a100:1] # Any option works, including SLURM settings
+```
+
+The example above launches 2 × 2 × 2 = 8 jobs. A value can also be a whole `class_path`/`init_args` block (or `null`), so you can sweep over entire components, e.g. comparing trainers or model architectures:
+
+```yaml
+grid:
+  trainer:
+    - class_path: TrainerConstructor
+      init_args:
+        callbacks: [{class_path: WandbCallback}]
+    - null # Default trainer
+```
+
 ### Pre-Pull Request Checklist
 
 Before starting a pull request, you'll want to run some checks on the changes you've made. 

--- a/src/main.py
+++ b/src/main.py
@@ -5,9 +5,8 @@ Subcommand = Literal['fit'] | Literal['test'] | Literal['format'] | Literal['eva
 
 
 def main(subcommand: Subcommand):
-    from mirror.slurm_launcher import submit_slurm_job
-    from mirror.slurm_util import parse_slurm_config
-    submit_slurm_job(parse_slurm_config(sys.argv[1:]), sys.argv[1:])
+    from mirror.slurm_launcher import submit_slurm_jobs
+    submit_slurm_jobs(sys.argv[1:])
 
     _run(subcommand)
 
@@ -54,6 +53,9 @@ def _run(subcommand: Subcommand):
             parser.add_subclass_arguments(TrainableModel, "model", required=True, instantiate=False)
             parser.add_subclass_arguments(TrainerConstructor, "trainer", required=False, instantiate=True)
             parser.add_argument("--device", type=str, choices=["cpu", "cuda"], default=None)
+            # Grid search options are expanded into separate jobs at submission time;
+            # registered here only so the `grid` config key is accepted, then ignored.
+            parser.add_argument("--grid", type=dict, default=None)
             cfg = parser.parse_args(resolve_config_args(sys.argv[2:]))
 
             run_config_yaml = f"subcommand: fit\n{parser.dump(cfg)}"
@@ -76,6 +78,7 @@ def _run(subcommand: Subcommand):
 
             del init.model # pyright: ignore
             del init.device # pyright: ignore
+            del init.grid # pyright: ignore
 
             fit(**{**init, "model": model, "trainer": trainer, "run_config_yaml": run_config_yaml})
 

--- a/src/mirror/slurm_launcher.py
+++ b/src/mirror/slurm_launcher.py
@@ -6,21 +6,33 @@ from pathlib import Path
 
 from jinja2 import Environment, FileSystemLoader, StrictUndefined
 
-from mirror.slurm_util import SlurmConfig
+from mirror.slurm_util import SlurmConfig, expand_grid, grid_override_args, parse_grid, parse_slurm_config
 from mirror.util import is_login_node
 
 
-def submit_slurm_job(slurm: SlurmConfig, python_args: list[str]) -> None:
-    """Submit a slurm job and exit, if `slurm.job_type` is 'compute' on a login node.
+def submit_slurm_jobs(python_args: list[str]) -> None:
+    """Submit one compute job per `grid` combination (one job if no grid), then exit.
 
     `python_args` is everything after the python script (e.g. `sys.argv[1:]`),
-    starting with the subcommand. Returns normally if no job was submitted;
-    calls `sys.exit` after a successful submission so the caller doesn't have
-    to bail out.
+    starting with the subcommand. No-op when not launching a compute job from a
+    login node, so the caller proceeds to run in-process.
     """
-    if not is_login_node() or slurm.job_type != "compute":
+    if not is_login_node():
         return
 
+    submitted = False
+    for combo in expand_grid(parse_grid(python_args)):
+        args = python_args + grid_override_args(combo)
+        slurm = parse_slurm_config(args)
+        if slurm.job_type == "compute":
+            _submit_one(slurm, args)
+            submitted = True
+
+    if submitted:
+        sys.exit(0)
+
+
+def _submit_one(slurm: SlurmConfig, python_args: list[str]) -> None:
     env = Environment(
         loader=FileSystemLoader(Path(__file__).parent / "templates"),
         undefined=StrictUndefined,
@@ -41,4 +53,3 @@ def submit_slurm_job(slurm: SlurmConfig, python_args: list[str]) -> None:
         )
     job_id = res.stdout.strip().split()[-1]
     print(f"Submitted batch job {job_id}")
-    sys.exit(0)

--- a/src/mirror/slurm_util.py
+++ b/src/mirror/slurm_util.py
@@ -1,3 +1,5 @@
+import itertools
+import json
 import os
 import re
 from dataclasses import dataclass
@@ -48,6 +50,43 @@ def parse_slurm_config(python_args: list[str]) -> SlurmConfig:
     slurm.ntasks_per_node = slurm.ntasks_per_node or trainer.get('devices') or 1
     slurm.gpus_per_node = slurm.gpus_per_node or str(trainer.get('devices') or 1)
     return slurm
+
+
+def parse_grid(python_args: list[str]) -> dict[str, list[Any]]:
+    """Extract the `grid` section: a mapping of dotted arg paths to value lists.
+
+    A scalar value is treated as a single-element list so it contributes one
+    point to the search.
+    """
+    section = _collect_sections(resolve_config_args(python_args), ('grid',))['grid']
+    return {path: value if isinstance(value, list) else [value] for path, value in section.items()}
+
+
+def expand_grid(grid: dict[str, list[Any]]) -> list[dict[str, Any]]:
+    """Cartesian product of the grid, yielding one override dict per combination.
+
+    An empty grid yields a single empty combination (i.e. one plain run).
+    """
+    paths = list(grid)
+    return [dict(zip(paths, values)) for values in itertools.product(*grid.values())]
+
+
+def grid_override_args(combo: dict[str, Any]) -> list[str]:
+    """Render a grid combination as `--path=value` CLI overrides."""
+    return [f"--{path}={_format_grid_value(value)}" for path, value in combo.items()]
+
+
+def _format_grid_value(value: Any) -> str:
+    # Collections (e.g. whole `class_path`/`init_args` configs) are emitted as
+    # JSON, which jsonargparse parses as flow YAML and round-trips faithfully.
+    # Scalars pass through so the parser applies the destination's own type.
+    if isinstance(value, (dict, list)):
+        return json.dumps(value)
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if value is None:
+        return "null"
+    return str(value)
 
 
 def _collect_sections(args: list[str], names: tuple[str, ...]) -> dict[str, dict[str, Any]]:


### PR DESCRIPTION
Tested by submitting training runs with the following config files:

config_grid_class.yaml:
```yaml
data:
  class_path: WikitextDataset
  init_args:
    split: train
    head: 50

model:
  class_path: mirror.models.mirror_llama_model.MirrorLlamaModel
  init_args:
    initialization:
      vocab_size: 128256
      hidden_size: 128
      intermediate_size: 340
      num_hidden_layers: 6
      num_attention_heads: 4

slurm:
  job_type: "compute"
  time: "00:10:00"
  gpus_per_node: p100:1

epochs: 1
batch_size: 1
device: cuda

grid:
  model.init_args.initialization:
    - {vocab_size: 128256, hidden_size: 128, intermediate_size: 340, num_hidden_layers: 6, num_attention_heads: 4}
    - {vocab_size: 128256, hidden_size: 256, intermediate_size: 680, num_hidden_layers: 8, num_attention_heads: 4}
  trainer:
    - class_path: TrainerConstructor
      init_args:
        callbacks:
          - class_path: WandbCallback
            init_args:
              log_every_n_steps: 5
    - null
```

config_grid_scalar.yaml:
```yaml
data:
  class_path: WikitextDataset
  init_args:
    split: train
    head: 50

model:
  class_path: mirror.models.mirror_llama_model.MirrorLlamaModel
  init_args:
    initialization:
      vocab_size: 128256
      hidden_size: 128
      intermediate_size: 340
      num_hidden_layers: 6
      num_attention_heads: 4

slurm:
  job_type: "compute"
  time: "00:10:00"
  gpus_per_node: p100:1

epochs: 1
batch_size: 1
device: cuda

grid:
  epochs: [1, 2]
  model.init_args.lr: [1e-3, 1e-4]
```

And confirming that in each case, 4 training runs are correctly submitted.
(Probably `scancel` those runs once you submit them; I actually got priority'd on the last 6 jobs)
Closes #40 