### PR TITLE
add predict_interactive

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "wandb",
     "jupyterlab==4.5.6",
     "ipykernel==7.2.0",
-    "prompt_tooklit==3.0.52"
+    "prompt_toolkit==3.0.52"
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "wandb",
     "jupyterlab==4.5.6",
     "ipykernel==7.2.0",
+    "prompt_tooklit==3.0.52"
 ]
 
 [project.optional-dependencies]

--- a/src/mirror/predictor.py
+++ b/src/mirror/predictor.py
@@ -20,6 +20,47 @@ class Predictor:
             top_k: int | None = None,
             repetition_penalty: float = 1.0,
     ) -> str:
+        self._load_checkpoint(model, fabric, checkpoint_path)
+        pipe = self._build_pipeline(model, fabric, formatter)
+        generation_kwargs = self._generation_kwargs(max_new_tokens, temperature, top_p, top_k, repetition_penalty)
+
+        result = pipe(text, **generation_kwargs)
+        return result[0]['generated_text']
+
+    def predict_interactive(
+            self,
+            model: InferenceModel,  # type: ignore[type-arg]
+            fabric: Fabric,
+            max_new_tokens: int,
+            checkpoint_path: str | None = None,
+            formatter: InferFriendlyFormatter | None = None,
+            temperature: float = 1.0,
+            top_p: float | None = None,
+            top_k: int | None = None,
+            repetition_penalty: float = 1.0,
+    ) -> None:
+        from prompt_toolkit import PromptSession
+
+        self._load_checkpoint(model, fabric, checkpoint_path)
+        pipe = self._build_pipeline(model, fabric, formatter)
+        generation_kwargs = self._generation_kwargs(max_new_tokens, temperature, top_p, top_k, repetition_penalty)
+
+        session: PromptSession[str] = PromptSession(multiline=True, prompt_continuation="... ")
+        try:
+            while True:
+                text = session.prompt("prompt> ")
+                if not text.strip():
+                    continue
+                print(pipe(text, **generation_kwargs)[0]['generated_text'])
+        except (KeyboardInterrupt, EOFError):
+            print()  # trailing newline so the shell prompt is on a new line
+
+    def _load_checkpoint(
+            self,
+            model: InferenceModel,  # type: ignore[type-arg]
+            fabric: Fabric,
+            checkpoint_path: str | None,
+    ) -> None:
         if checkpoint_path is not None:
             if os.path.isdir(checkpoint_path):
                 import torch.distributed.checkpoint as dcp
@@ -29,17 +70,31 @@ class Predictor:
             else:
                 fabric.load(checkpoint_path, {'model': model})
 
+    def _build_pipeline(
+            self,
+            model: InferenceModel,  # type: ignore[type-arg]
+            fabric: Fabric,
+            formatter: InferFriendlyFormatter | None,
+    ):
         model.eval()
 
         active_formatter = formatter or cast(InferFriendlyFormatter, model.formatter)
 
-        pipe = hf_pipeline(
+        return hf_pipeline(
             'text-generation',
             model=model.hf_model,
             tokenizer=active_formatter.tokenizer,
             device=fabric.device,
         )
 
+    def _generation_kwargs(
+            self,
+            max_new_tokens: int,
+            temperature: float,
+            top_p: float | None,
+            top_k: int | None,
+            repetition_penalty: float,
+    ) -> dict:
         do_sample = temperature != 1.0 or top_p is not None or top_k is not None
         generation_kwargs: dict = dict(
             max_new_tokens=max_new_tokens,
@@ -51,6 +106,4 @@ class Predictor:
             generation_kwargs['top_p'] = top_p
         if top_k is not None:
             generation_kwargs['top_k'] = top_k
-
-        result = pipe(text, **generation_kwargs)
-        return result[0]['generated_text']
+        return generation_kwargs

--- a/src/mirror/subcommands.py
+++ b/src/mirror/subcommands.py
@@ -71,8 +71,9 @@ def evaluation(
 def infer(
         model: InferenceModel,  # type: ignore[type-arg]
         fabric: Fabric,
-        text: str,
         max_new_tokens: int,
+        text: str | None = None,
+        interactive: bool = False,
         checkpoint_path: str | None = None,
         formatter: InferFriendlyFormatter | None = None,
         temperature: float = 1.0,
@@ -82,7 +83,26 @@ def infer(
         slurm: SlurmConfig = SlurmConfig(),
 ) -> None:
     from mirror.predictor import Predictor
-    result = Predictor().predict(
+    predictor = Predictor()
+
+    if interactive:
+        predictor.predict_interactive(
+            model=model,
+            fabric=fabric,
+            checkpoint_path=checkpoint_path,
+            formatter=formatter,
+            max_new_tokens=max_new_tokens,
+            temperature=temperature,
+            top_p=top_p,
+            top_k=top_k,
+            repetition_penalty=repetition_penalty,
+        )
+        return
+
+    if text is None:
+        raise ValueError("`text` is required unless `--interactive` is set.")
+
+    result = predictor.predict(
         model=model,
         fabric=fabric,
         checkpoint_path=checkpoint_path,

--- a/src/mirror/subcommands.py
+++ b/src/mirror/subcommands.py
@@ -86,6 +86,15 @@ def infer(
     predictor = Predictor()
 
     if interactive:
+        import sys
+        if slurm.job_type == "compute":
+            raise ValueError(
+                "`--interactive` cannot be used with `--slurm.job_type=compute`; use `--slurm.job_type=local`."
+            )
+        if not sys.stdin.isatty():
+            raise ValueError(
+                "`--interactive` requires a TTY (run locally or within an interactive allocation)."
+            )
         predictor.predict_interactive(
             model=model,
             fabric=fabric,


### PR DESCRIPTION
Closes #403

Tested by running interactive compute on an `salloc`'d compute node. Verified that you can add mutli-line prompts, alt+enter to send, arrows to go do previous prompts and ctrl+c to quit.