### PR TITLE
Implement config file language validation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,6 +2,7 @@
   "recommendations": [
     "ms-python.python",
     "charliermarsh.ruff",
-    "ms-python.vscode-pylance"
+    "ms-python.vscode-pylance",
+    "redhat.vscode-yaml"
   ]
 }

--- a/configs/demo_configs/demo_fit_config.yaml
+++ b/configs/demo_configs/demo_fit_config.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/fit.schema.json
 data:
   class_path: WikitextDataset
   init_args:

--- a/configs/demo_configs/demo_format_config.yaml
+++ b/configs/demo_configs/demo_format_config.yaml
@@ -1,14 +1,15 @@
+# yaml-language-server: $schema=../../schemas/format.schema.json
 data:
-  class_path: 
+  class_path:
     WikitextDataset
   init_args:
     split: train
     head: 1000
 
-formatter: 
+formatter:
   class_path: MirrorLlamaFormatter
   init_args:
-    vocab_size: 128256
+    max_length: 2048
 
 # checkpoint:
 #   training_run_id: <training_run_id>
@@ -24,5 +25,3 @@ slurm:
   open_mode: "append"
   signal: "SIGHUP@90"
   requeue: true
-
-device: cuda

--- a/configs/demo_configs/demo_infer_config.yaml
+++ b/configs/demo_configs/demo_infer_config.yaml
@@ -1,11 +1,12 @@
+# yaml-language-server: $schema=../../schemas/infer.schema.json
 model:
   class_path: MirrorGPTModel
   init_args:
     weights: pretrained
 
 checkpoint_path:
-text:
-num_tokens: 100
+text: "Once upon a time"
+max_new_tokens: 100
 temperature: 0.8
 top_p: 0.95
 repetition_penalty: 1.2

--- a/configs/test_configs/overfit_test_config.yaml
+++ b/configs/test_configs/overfit_test_config.yaml
@@ -1,3 +1,4 @@
+# yaml-language-server: $schema=../../schemas/fit.schema.json
 data:
   class_path: WikitextDataset
   init_args:

--- a/schemas/eval.schema.json
+++ b/schemas/eval.schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "config": {},
+    "metrics": {},
+    "checkpoint_path": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "slurm": {
+      "type": "object",
+      "properties": {
+        "job_type": {
+          "enum": [
+            "compute",
+            "local",
+            "local-download"
+          ]
+        },
+        "time": {
+          "type": "string"
+        },
+        "nodes": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "ntasks_per_node": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "gpus_per_node": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mem_per_cpu": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        },
+        "open_mode": {
+          "type": "string"
+        },
+        "signal": {
+          "type": "string"
+        },
+        "requeue": {
+          "type": "boolean"
+        },
+        "qos": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "model": {},
+    "strategy": {},
+    "device": {
+      "enum": [
+        "cpu",
+        "cuda",
+        null
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/fit.schema.json
+++ b/schemas/fit.schema.json
@@ -1,0 +1,91 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "config": {},
+    "data": {},
+    "formatter": {},
+    "checkpoint": {},
+    "slurm": {
+      "type": "object",
+      "properties": {
+        "job_type": {
+          "enum": [
+            "compute",
+            "local",
+            "local-download"
+          ]
+        },
+        "time": {
+          "type": "string"
+        },
+        "nodes": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "ntasks_per_node": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "gpus_per_node": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mem_per_cpu": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        },
+        "open_mode": {
+          "type": "string"
+        },
+        "signal": {
+          "type": "string"
+        },
+        "requeue": {
+          "type": "boolean"
+        },
+        "qos": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "epochs": {
+      "type": "integer"
+    },
+    "batch_size": {
+      "type": "integer"
+    },
+    "val_data": {},
+    "test_data": {},
+    "val_check_interval": {
+      "type": "integer"
+    },
+    "configure_scheduler": {},
+    "shuffle": {
+      "type": "boolean"
+    },
+    "optimization_strategy": {},
+    "model": {},
+    "trainer": {},
+    "device": {
+      "enum": [
+        "cpu",
+        "cuda",
+        null
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/format.schema.json
+++ b/schemas/format.schema.json
@@ -1,0 +1,65 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "config": {},
+    "data": {},
+    "formatter": {},
+    "slurm": {
+      "type": "object",
+      "properties": {
+        "job_type": {
+          "enum": [
+            "compute",
+            "local",
+            "local-download"
+          ]
+        },
+        "time": {
+          "type": "string"
+        },
+        "nodes": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "ntasks_per_node": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "gpus_per_node": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mem_per_cpu": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        },
+        "open_mode": {
+          "type": "string"
+        },
+        "signal": {
+          "type": "string"
+        },
+        "requeue": {
+          "type": "boolean"
+        },
+        "qos": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "additionalProperties": false
+}

--- a/schemas/infer.schema.json
+++ b/schemas/infer.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {
+    "config": {},
+    "text": {
+      "type": "string"
+    },
+    "max_new_tokens": {
+      "type": "integer"
+    },
+    "checkpoint_path": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "formatter": {},
+    "temperature": {
+      "type": "number"
+    },
+    "top_p": {
+      "type": [
+        "number",
+        "null"
+      ]
+    },
+    "top_k": {
+      "type": [
+        "integer",
+        "null"
+      ]
+    },
+    "repetition_penalty": {
+      "type": "number"
+    },
+    "slurm": {
+      "type": "object",
+      "properties": {
+        "job_type": {
+          "enum": [
+            "compute",
+            "local",
+            "local-download"
+          ]
+        },
+        "time": {
+          "type": "string"
+        },
+        "nodes": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "ntasks_per_node": {
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "gpus_per_node": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "mem_per_cpu": {
+          "type": "string"
+        },
+        "output": {
+          "type": "string"
+        },
+        "open_mode": {
+          "type": "string"
+        },
+        "signal": {
+          "type": "string"
+        },
+        "requeue": {
+          "type": "boolean"
+        },
+        "qos": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "additionalProperties": false
+    },
+    "model": {},
+    "strategy": {},
+    "device": {
+      "enum": [
+        "cpu",
+        "cuda",
+        null
+      ]
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/main.py
+++ b/src/main.py
@@ -15,28 +15,14 @@ def main(subcommand: Subcommand):
 def _run(subcommand: Subcommand):
     import warnings
 
-    from jsonargparse import ActionConfigFile, ArgumentParser
     from lightning.fabric.utilities.warnings import PossibleUserWarning
-    from lightning.fabric.strategies.strategy import Strategy
 
+    from mirror.cli_parsers import build_parser
     from mirror.config import init_config
-    from mirror.models.trainable_model import TrainableModel
     from mirror.models.model_util import instantiate_model
     from mirror.subcommands import evaluation, fit, format, infer
     from mirror.trainer_constructor import TrainerConstructor
     from mirror.util import is_login_node, resolve_config_args
-
-    # These are required so that their items can be found easily by jsonargparse without
-    # having to give the full classpath
-    import lightning.fabric.strategies  # noqa: F401
-    import mirror.callbacks  # noqa: F401
-    import mirror.datasets  # noqa: F401
-    import mirror.models  # noqa: F401
-    import mirror.optimization  # noqa: F401
-    import mirror.formatters  # noqa: F401
-    import mirror.schedulers  # noqa: F401
-    import mirror.interventions  # noqa: F401
-    import mirror.metrics  # noqa: F401
 
     # These warnings happen internal to Fabric, so there's not much we can do about them.
     warnings.filterwarnings('ignore', category=FutureWarning, message='.*Please use DTensor instead and we are deprecating ShardedTensor.*')
@@ -48,12 +34,7 @@ def _run(subcommand: Subcommand):
 
     match subcommand:
         case 'fit':
-            parser = ArgumentParser()
-            parser.add_argument("--config", action=ActionConfigFile)
-            parser.add_function_arguments(fit, as_positional=False, skip={"model", "trainer", "run_config_yaml"})
-            parser.add_subclass_arguments(TrainableModel, "model", required=True, instantiate=False)
-            parser.add_subclass_arguments(TrainerConstructor, "trainer", required=False, instantiate=True)
-            parser.add_argument("--device", type=str, choices=["cpu", "cuda"], default=None)
+            parser = build_parser('fit')
             cfg = parser.parse_args(resolve_config_args(sys.argv[2:]))
 
             run_config_yaml = f"subcommand: fit\n{parser.dump(cfg)}"
@@ -80,9 +61,7 @@ def _run(subcommand: Subcommand):
             fit(**{**init, "model": model, "trainer": trainer, "run_config_yaml": run_config_yaml})
 
         case 'format':
-            parser = ArgumentParser()
-            parser.add_argument("--config", action=ActionConfigFile)
-            parser.add_function_arguments(format, as_positional=False)
+            parser = build_parser('format')
             cfg = parser.parse_args(resolve_config_args(sys.argv[2:]))
 
             if hasattr(cfg, 'config'):
@@ -92,12 +71,7 @@ def _run(subcommand: Subcommand):
             format(**init)
 
         case 'eval':
-            parser = ArgumentParser()
-            parser.add_argument("--config", action=ActionConfigFile)
-            parser.add_function_arguments(evaluation, as_positional=False, skip={"model", "fabric"})
-            parser.add_subclass_arguments(TrainableModel, "model", required=True, instantiate=False)
-            parser.add_argument("--strategy", type=Strategy)
-            parser.add_argument("--device", type=str, choices=["cpu", "cuda"], default=None)
+            parser = build_parser('eval')
             cfg = parser.parse_args(resolve_config_args(sys.argv[2:]))
 
             if hasattr(cfg, 'config'):
@@ -131,16 +105,10 @@ def _run(subcommand: Subcommand):
             evaluation(**{**init, "model": model, "fabric": fabric})
 
         case 'infer':
-            from mirror.models.inference_model import InferenceModel
             from mirror.config import get_config
             from mirror.fabric_util import make_fabric
 
-            parser = ArgumentParser()
-            parser.add_argument("--config", action=ActionConfigFile)
-            parser.add_function_arguments(infer, as_positional=False, skip={"model", "fabric"})
-            parser.add_subclass_arguments(InferenceModel, "model", required=True, instantiate=False)
-            parser.add_argument("--strategy", type=Strategy, default="fsdp")
-            parser.add_argument("--device", type=str, choices=["cpu", "cuda"], default=None)
+            parser = build_parser('infer')
             cfg = parser.parse_args(resolve_config_args(sys.argv[2:]))
 
             if hasattr(cfg, 'config'):

--- a/src/mirror/cli_parsers.py
+++ b/src/mirror/cli_parsers.py
@@ -1,0 +1,49 @@
+from jsonargparse import ActionConfigFile, ArgumentParser
+from lightning.fabric.strategies.strategy import Strategy
+
+from mirror.subcommands import evaluation, fit, format, infer
+from mirror.models.trainable_model import TrainableModel
+from mirror.models.inference_model import InferenceModel
+from mirror.trainer_constructor import TrainerConstructor
+
+# These imports register the subclasses so jsonargparse can resolve them by
+# short name (e.g. `class_path: WikitextDataset`) in config files.
+import lightning.fabric.strategies  # noqa: F401
+import mirror.callbacks  # noqa: F401
+import mirror.datasets  # noqa: F401
+import mirror.models  # noqa: F401
+import mirror.optimization  # noqa: F401
+import mirror.formatters  # noqa: F401
+import mirror.schedulers  # noqa: F401
+import mirror.interventions  # noqa: F401
+import mirror.metrics  # noqa: F401
+
+
+def build_parser(subcommand: str) -> ArgumentParser:
+    """Build the argument parser for a subcommand.
+
+    This is the single source of truth for each subcommand's arguments, shared
+    by the runtime (main.py) and the config-schema generator (config_schema.py)
+    so the two never drift apart.
+    """
+    parser = ArgumentParser()
+    parser.add_argument("--config", action=ActionConfigFile)
+    match subcommand:
+        case 'fit':
+            parser.add_function_arguments(fit, as_positional=False, skip={"model", "trainer", "run_config_yaml"})
+            parser.add_subclass_arguments(TrainableModel, "model", required=True, instantiate=False)
+            parser.add_subclass_arguments(TrainerConstructor, "trainer", required=False, instantiate=True)
+            parser.add_argument("--device", type=str, choices=["cpu", "cuda"], default=None)
+        case 'format':
+            parser.add_function_arguments(format, as_positional=False)
+        case 'eval':
+            parser.add_function_arguments(evaluation, as_positional=False, skip={"model", "fabric"})
+            parser.add_subclass_arguments(TrainableModel, "model", required=True, instantiate=False)
+            parser.add_argument("--strategy", type=Strategy)
+            parser.add_argument("--device", type=str, choices=["cpu", "cuda"], default=None)
+        case 'infer':
+            parser.add_function_arguments(infer, as_positional=False, skip={"model", "fabric"})
+            parser.add_subclass_arguments(InferenceModel, "model", required=True, instantiate=False)
+            parser.add_argument("--strategy", type=Strategy, default="fsdp")
+            parser.add_argument("--device", type=str, choices=["cpu", "cuda"], default=None)
+    return parser

--- a/src/mirror/config_schema.py
+++ b/src/mirror/config_schema.py
@@ -1,0 +1,95 @@
+"""Generate JSON Schemas for config files from the jsonargparse parsers.
+
+The schemas let the VS Code Red Hat YAML extension validate config files as you
+edit them. Validation is intentionally top-level only: it catches unknown keys
+(typos), wrong scalar types, and bad enum values. It does not validate the
+`init_args` of polymorphic `class_path` subclasses, which are open-ended.
+
+Regenerate with: python -m mirror.config_schema
+"""
+import json
+import types
+import typing
+from pathlib import Path
+
+from jsonargparse import ArgumentParser
+
+from mirror.cli_parsers import build_parser
+
+SUBCOMMANDS = ("fit", "format", "eval", "infer")
+_SCHEMAS_DIR = Path(__file__).parent.parent.parent / "schemas"
+_SIMPLE = {int: "integer", float: "number", str: "string", bool: "boolean"}
+_LEAF = "__action__"
+
+
+def _nullable(schema: dict) -> dict:
+    if isinstance(schema.get("type"), str):
+        schema["type"] = [schema["type"], "null"]
+    elif "enum" in schema and None not in schema["enum"]:
+        schema["enum"].append(None)
+    return schema
+
+
+def _type_schema(hint) -> dict:
+    """Map a type hint to a JSON Schema fragment; unknown/complex types allow anything."""
+    if typing.get_origin(hint) is typing.Literal:
+        return {"enum": list(typing.get_args(hint))}
+    if typing.get_origin(hint) is typing.Union or isinstance(hint, types.UnionType):
+        non_none = [a for a in typing.get_args(hint) if a is not type(None)]
+        nullable = len(non_none) != len(typing.get_args(hint))
+        if len(non_none) == 1:
+            sub = _type_schema(non_none[0])
+            return _nullable(sub) if nullable else sub
+        return {}
+    return {"type": _SIMPLE[hint]} if hint in _SIMPLE else {}
+
+
+def _action_schema(action) -> dict:
+    if getattr(action, "choices", None):
+        return {"enum": list(action.choices) + [None]}
+    return _type_schema(getattr(action, "_typehint", None))
+
+
+def _insert(tree: dict, parts: list[str], action) -> None:
+    node = tree
+    for part in parts[:-1]:
+        if not isinstance(node.get(part), dict) or _LEAF in node[part]:
+            node[part] = {}
+        node = node[part]
+    node.setdefault(parts[-1], {_LEAF: action})
+
+
+def _build_props(node: dict) -> dict:
+    props = {}
+    for name, child in node.items():
+        if _LEAF in child:
+            props[name] = _action_schema(child[_LEAF])
+        else:
+            props[name] = {"type": "object", "properties": _build_props(child), "additionalProperties": False}
+    return props
+
+
+def generate_schema(parser: ArgumentParser) -> dict:
+    tree: dict = {}
+    for action in parser._actions:
+        dest = action.dest
+        if dest in ("help", "print_config") or dest.endswith(".help"):
+            continue
+        _insert(tree, dest.split("."), action)
+    return {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": _build_props(tree),
+        "additionalProperties": False,
+    }
+
+
+def write_schemas(out_dir: Path = _SCHEMAS_DIR) -> None:
+    out_dir.mkdir(exist_ok=True)
+    for subcommand in SUBCOMMANDS:
+        schema = generate_schema(build_parser(subcommand))
+        (out_dir / f"{subcommand}.schema.json").write_text(json.dumps(schema, indent=2) + "\n")
+
+
+if __name__ == "__main__":
+    write_schemas()

--- a/src/mirror/subcommands.py
+++ b/src/mirror/subcommands.py
@@ -99,5 +99,6 @@ def infer(
 def format(
         data: MirrorDataset,
         formatter: MirrorFormatter,
+        slurm: SlurmConfig = SlurmConfig(),
 ) -> None:
     formatter.format_data(data)


### PR DESCRIPTION
Tested by confirming that valid config files raise no errors, and editing one to have `epochs: one` instead of `epochs: 1` and confirming that it raises an error. 
Notes:
- Make sure you guys install the YAML extension by Red Hat to allow this to work
- You'll need to paste the following at the top of a config file for it to get validated:
```# yaml-language-server: $schema=../../schemas/<subcommand>.schema.json```
With `<subcommand>` being `fit`/`eval`/`format`/`infer` - whatever subcommand the config file is for

Closes #61 